### PR TITLE
qasm/qlink IIgs Self build

### DIFF
--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -20,7 +20,7 @@ asm          php
 :getlen      pha
              pha
              psl   filehandle
-             tll   $1802
+             _GetHandleSize
              plx
              ply
              jcs   :incerr
@@ -876,7 +876,7 @@ printline    php
              pha
              _QATabToCol
              psl   #opcode
-             tll   $1c0c
+             _WriteString
              lda   tabs+2
              and   #$ff
              pha
@@ -887,7 +887,7 @@ printline    php
              dec   linebuff
              rep   $20
              psl   #linebuff
-             tll   $1c0c
+             _WriteString
 :comment     rep   $30
              lda   tabs+3
              and   #$ff
@@ -895,7 +895,7 @@ printline    php
              _QATabToCol
 :comment1    rep   $30
              psl   #comment
-             tll   $1c0c
+             _WriteString
 :xit         rep   $30
              jsr   printcycles
              lda   #$0d
@@ -1260,7 +1260,7 @@ getmemory
              pha
              pea   $8000                               ;locked page aligned
              psl   #$00
-             tll   $0902
+             _NewHandle
              plx
              ply
              bcc   :m1out
@@ -1294,7 +1294,7 @@ getmemory
              pha
              pea   $8000                               ;locked page aligned no bank cross
              psl   #$00
-             tll   $0902
+             _NewHandle
              plx
              ply
              bcc   :m2out
@@ -1328,7 +1328,7 @@ getmemory
              pha
              pea   $8000
              psl   #$00
-             tll   $0902
+             _NewHandle
              plx
              ply
              bcc   :m3out
@@ -1362,8 +1362,8 @@ getmemory
              sec
              ror   :purgeflag
              pea   $00
-             tll   $1302                               ;purgeall
-             tll   $1f02                               ;compactmem
+             _PurgeAll
+             _CompactMem
              clc
              rts
 :psec        sec
@@ -1374,15 +1374,15 @@ disposemem   php
              ldal  userid
              ora   #memid
              pha
-             _disposeall
+             _DisposeAll
              ldal  userid
              ora   #putid
              pha
-             _disposeall
+             _DisposeAll
              ldal  userid
              ora   #useid
              pha
-             _disposeall
+             _DisposeAll
              plp
              rts
 
@@ -1605,7 +1605,7 @@ inclablect   php
              pha
              pea   $8004                               ;page aligned/locked
              psl   #$00
-             tll   $0902
+             _NewHandle
              plx
              ply
              jcs   :sec

--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -29,7 +29,7 @@ asm          php
              dey
 :dec1        dex
 
-:nodec       stx   filelendd
+:nodec       stx   filelen
              sty   filelen+2
 
              ldy   #$04

--- a/src/asm/asm.cmd.s
+++ b/src/asm/asm.cmd.s
@@ -3,19 +3,18 @@
                   ;use   ../macs/qatools.macs.s
                   ;use   ../macs/toolmacs.s
 
-            put   asm.vars
-            put   asm.1
-            put   asm.eval
-            put   asm.cond
-            put   asm.opcodes
-            put   asm.dsk
-            put   asm.errors
-            put   ../data/opdata
+            ovr   all
+*            put   asm.vars
+*            put   asm.1
+*            put   asm.eval
+*            put   asm.cond
+*            put   asm.opcodes
+*            put   asm.dsk
+*            put   asm.errors
+*            put   ../data/opdata
             asm   asm.header
 
-            lnk   ../utility/qasmgs.l
+            lnk   qasmgs.l
             typ   exe
-            sav   ../utility/qasmgs
-mylable     equ   $1234
-            ent
+            sav   qasmgs
 

--- a/src/asm/asm.dsk.s
+++ b/src/asm/asm.dsk.s
@@ -162,13 +162,13 @@ dskop        php
              pha
              lda           objhdl
              pha
-             _hunlock
+             _HUnlock
              psl           #dskobjsize+1
              lda           objhdl+2
              pha
              lda           objhdl
              pha
-             tll           $1902                                     ;set handlesize
+             _SetHandleSize
              lda           #dskobjsize
              sta           objsize
              lda           objhdl+2
@@ -177,7 +177,7 @@ dskop        php
              lda           objhdl
              sta           workspace
              pha
-             _hlock
+             _HLock
              ldy           #$02
              lda           [workspace]
              sta           objzpptr
@@ -841,7 +841,7 @@ putop        php
              lda           userid
              ora           #putid
              pha
-             _disposeall
+             _DisposeAll
              sec
              ror           :purgeflag
              lda           #$0000
@@ -877,7 +877,7 @@ putop        php
              lda           putbuffer+2,x
              sta           workspace+2
              pha
-             _hlock
+             _HLock
              plx
              lda           fileptr
              sta           putbuffer+4,x
@@ -898,7 +898,7 @@ putop        php
              psl           #$00
              pei           workspace+2
              pei           workspace
-             tll           $1802                                     ;gethandlesize
+             _GetHandleSize
              plx
              ply
              cpx           #$00
@@ -1009,7 +1009,7 @@ useop        php
              lda           usebuffer+2,x
              sta           workspace+2
              pha
-             _hlock
+             _HLock
              plx
              lda           fileptr
              sta           usebuffer+4,x
@@ -1030,7 +1030,7 @@ useop        php
              psl           #$00
              pei           workspace+2
              pei           workspace
-             tll           $1802                                     ;gethandlesize
+             _GetHandleSize
              plx
              ply
              cpx           #$00
@@ -1110,7 +1110,7 @@ putend       php
              phx
              pei           workspace+2
              pei           workspace
-             _hunlock
+             _HUnlock
              plx
              lda           putbuffer+4,x
              sta           fileptr

--- a/src/asm/asm.eval.s
+++ b/src/asm/asm.eval.s
@@ -729,7 +729,7 @@ dodiv         php
               pha
               lda   xreg
               pha
-              tll   $0d0b
+              _LongDivide
               pla
               sta   xreg
               pla
@@ -765,7 +765,7 @@ domod         php
               pha
               lda   xreg
               pha
-              tll   $0d0b
+              _LongDivide
               pla
               pla
               pla

--- a/src/asm/asm.header.s
+++ b/src/asm/asm.header.s
@@ -9,8 +9,12 @@
             mx    %00               ; make sure we're in 16-bit mode!
 
             ;use   util.macs
-            use   qatools.macs
+            use   ../macros/builtin.macs
+            use   ../macros/qatools.macs
             use   ../data/qa.equates
+
+            use   asm.macs
+
 
             brl   start
 
@@ -398,7 +402,9 @@ indexj      da    5*2               ; these indexes is crucial
 array       da    1,1,2,3,5,8,13,21,54,75,129,204
             da    323,527,850,1377,2227
 
+            do    0
             err   *-array-34
+            fin
 
 *=================================================
 * SEED seeds generator from 16 bit contents of AXY
@@ -477,5 +483,5 @@ randomize   php
             lst   off
 
             ;typ   exe
-            ;sav   utility/qasmgs.l
+            sav   qasmgs.l
 

--- a/src/asm/asm.header.s
+++ b/src/asm/asm.header.s
@@ -76,7 +76,7 @@ start       php
             lda   userid
             ora   #asmmemid
             pha
-            _disposeall
+            _DisposeAll
             pla
             pld
             plb
@@ -328,7 +328,7 @@ printdec    php
             psl   #:str
             pea   #11
             pea   $00
-            tll   $270b
+            _Long2Dec
             sep   $30
             ldy   #$00
             ldx   #$00
@@ -347,7 +347,7 @@ printdec    php
             rep   $30
             jsr   drawchar
 * pha
-* tll $180c
+* _WriteChar
             sep   $30
             plx
             ply

--- a/src/asm/asm.macs.s
+++ b/src/asm/asm.macs.s
@@ -17,6 +17,12 @@ _SetHandleSize MAC
 _NewHandle MAC
         tll $902
         <<<
+_PurgeAll MAC
+        tll $1302
+        <<<
+_CompactMem MAC
+        tll $1F02
+        <<<
 _ReadTimeHex MAC
         tll $D03
         <<<
@@ -26,12 +32,14 @@ _ReadAsciiTime MAC
 _SysBeep MAC
         tll $2C03
         <<<
-
 _Long2Dec MAC
         tll $270B
         <<<
 _LongDivide MAC
         tll $D0B
+        <<<
+_WriteString MAC
+        tll $1C0C
         <<<
 
 _SANEFP816      MAC

--- a/src/asm/asm.macs.s
+++ b/src/asm/asm.macs.s
@@ -1,134 +1,160 @@
 
-_DisposeAll	MAC
-	tll	$1102
-	<<<
+_DisposeAll     MAC
+        tll     $1102
+        <<<
+_HLock  MAC
+        tll     $2002
+        <<<
+_HUnlock        MAC
+        tll     $2202
+        <<<
+_GetHandleSize MAC
+        tll $1802
+        <<<
+_SetHandleSize MAC
+        tll $1902
+        <<<
+_NewHandle MAC
+        tll $902
+        <<<
+_ReadTimeHex MAC
+        tll $D03
+        <<<
+_ReadAsciiTime MAC
+        tll $F03
+        <<<
+_SysBeep MAC
+        tll $2C03
+        <<<
 
-_HLock	MAC
-	tll	$2002
-	<<<
-_HUnlock	MAC
-	tll	$2202
-	<<<
+_Long2Dec MAC
+        tll $270B
+        <<<
+_LongDivide MAC
+        tll $D0B
+        <<<
 
-_SANEFP816	MAC
-	tll	$90A
-	<<<
-_SANEDecStr816	MAC
-	tll	$A0A
-	<<<
+_SANEFP816      MAC
+        tll     $90A
+        <<<
+_SANEDecStr816  MAC
+        tll     $A0A
+        <<<
 
-FOPRF	MAC		;call FP
-	PEA	]1
-	_SANEFP816
-	<<<
-FOPRD	MAC		;call DecStr
-	PEA	]1
-	_SANEDecStr816
-	<<<
+FOPRF   MAC             ;call FP
+        PEA     ]1
+        _SANEFP816
+        <<<
+FOPRD   MAC             ;call DecStr
+        PEA     ]1
+        _SANEDecStr816
+        <<<
 
-FDEC2X	MAC
-	FOPRF	$009
-	<<<
-FPSTR2DEC	MAC		;pascal string to decimal record
-	FOPRD	0
-	<<<
+FDEC2X  MAC
+        FOPRF   $009
+        <<<
+FPSTR2DEC       MAC             ;pascal string to decimal record
+        FOPRD   0
+        <<<
 
 
 
-_setmark	MAC
-	jsl	$e100a8
-	da	$16
-	adrl	]1
-	<<<
 
-_getmark	MAC
-	jsl	$e100a8
-	da	$17
-	adrl	]1
-	<<<
 
-_getprefix	MAC
-	jsl	$e100a8
-	da	$0a
-	adrl	]1
-	<<<
+_setmark        MAC
+        jsl     $e100a8
+        da      $16
+        adrl    ]1
+        <<<
 
-_create	MAC
-	jsl	$e100a8
-	da	$01
-	adrl	]1
-	<<<
+_getmark        MAC
+        jsl     $e100a8
+        da      $17
+        adrl    ]1
+        <<<
 
-_setfileinfo	MAC
-	jsl	$e100a8
-	da	$05
-	adrl	]1
-	<<<
-_getfileinfo	MAC
-	jsl	$e100a8
-	da	$06
-	adrl	]1
-	<<<
+_getprefix      MAC
+        jsl     $e100a8
+        da      $0a
+        adrl    ]1
+        <<<
 
-_open	MAC
-	jsl	$e100a8
-	da	$10
-	adrl	]1
-	<<<
-_write	MAC
-	jsl	$e100a8
-	da	$13
-	adrl	]1
-	<<<
-_close	MAC
-	jsl	$e100a8
-	da	$14
-	adrl	]1
-	<<<
-_seteof	MAC
-	jsl	$e100a8
-	da	$18
-	adrl	]1
-	<<<
+_create MAC
+        jsl     $e100a8
+        da      $01
+        adrl    ]1
+        <<<
 
-opno	mac
-	sec
-	rts
-	<<<
+_setfileinfo    MAC
+        jsl     $e100a8
+        da      $05
+        adrl    ]1
+        <<<
+_getfileinfo    MAC
+        jsl     $e100a8
+        da      $06
+        adrl    ]1
+        <<<
 
-opco	mac
-	db	$c9	; cmp #
-	usr	]1
-	bne	nope
-	ldx	#]2
-	ldy	#]3
-	clc
-	rts
+_open   MAC
+        jsl     $e100a8
+        da      $10
+        adrl    ]1
+        <<<
+_write  MAC
+        jsl     $e100a8
+        da      $13
+        adrl    ]1
+        <<<
+_close  MAC
+        jsl     $e100a8
+        da      $14
+        adrl    ]1
+        <<<
+_seteof MAC
+        jsl     $e100a8
+        da      $18
+        adrl    ]1
+        <<<
+
+opno    mac
+        sec
+        rts
+        <<<
+
+opco    mac
+        db      $c9     ; cmp #
+        usr     ]1
+        bne     nope
+        ldx     #]2
+        ldy     #]3
+        clc
+        rts
 nope
-	<<<
+        <<<
 
-opcl	mac
-	if $=]1
-	else
-	opco ]1;]2;]3
-	fin
-	sec
-	rts
-	<<<
+opcl    mac
+        if $=]1
+        else
+        opco ]1;]2;]3
+        fin
+        sec
+        rts
+        <<<
 
-opcx	mac
-	db	$c9	; cmp #
-	usr	]1
-	bne	nope
-	ldx	#]2
-	ldy	#^]2
-	clc
-	rts
+opcx    mac
+        db      $c9     ; cmp #
+        usr     ]1
+        bne     nope
+        ldx     #]2
+        ldy     #^]2
+        clc
+        rts
 nope
-	<<<
+        <<<
 
-opcxl	mac
-	opcx ]1;]2
-	sec
-	rts
-	<<<
+opcxl   mac
+        opcx ]1;]2
+        sec
+        rts
+        <<<

--- a/src/asm/asm.macs.s
+++ b/src/asm/asm.macs.s
@@ -1,0 +1,134 @@
+
+_DisposeAll	MAC
+	tll	$1102
+	<<<
+
+_HLock	MAC
+	tll	$2002
+	<<<
+_HUnlock	MAC
+	tll	$2202
+	<<<
+
+_SANEFP816	MAC
+	tll	$90A
+	<<<
+_SANEDecStr816	MAC
+	tll	$A0A
+	<<<
+
+FOPRF	MAC		;call FP
+	PEA	]1
+	_SANEFP816
+	<<<
+FOPRD	MAC		;call DecStr
+	PEA	]1
+	_SANEDecStr816
+	<<<
+
+FDEC2X	MAC
+	FOPRF	$009
+	<<<
+FPSTR2DEC	MAC		;pascal string to decimal record
+	FOPRD	0
+	<<<
+
+
+
+_setmark	MAC
+	jsl	$e100a8
+	da	$16
+	adrl	]1
+	<<<
+
+_getmark	MAC
+	jsl	$e100a8
+	da	$17
+	adrl	]1
+	<<<
+
+_getprefix	MAC
+	jsl	$e100a8
+	da	$0a
+	adrl	]1
+	<<<
+
+_create	MAC
+	jsl	$e100a8
+	da	$01
+	adrl	]1
+	<<<
+
+_setfileinfo	MAC
+	jsl	$e100a8
+	da	$05
+	adrl	]1
+	<<<
+_getfileinfo	MAC
+	jsl	$e100a8
+	da	$06
+	adrl	]1
+	<<<
+
+_open	MAC
+	jsl	$e100a8
+	da	$10
+	adrl	]1
+	<<<
+_write	MAC
+	jsl	$e100a8
+	da	$13
+	adrl	]1
+	<<<
+_close	MAC
+	jsl	$e100a8
+	da	$14
+	adrl	]1
+	<<<
+_seteof	MAC
+	jsl	$e100a8
+	da	$18
+	adrl	]1
+	<<<
+
+opno	mac
+	sec
+	rts
+	<<<
+
+opco	mac
+	db	$c9	; cmp #
+	usr	]1
+	bne	nope
+	ldx	#]2
+	ldy	#]3
+	clc
+	rts
+nope
+	<<<
+
+opcl	mac
+	if $=]1
+	else
+	opco ]1;]2;]3
+	fin
+	sec
+	rts
+	<<<
+
+opcx	mac
+	db	$c9	; cmp #
+	usr	]1
+	bne	nope
+	ldx	#]2
+	ldy	#^]2
+	clc
+	rts
+nope
+	<<<
+
+opcxl	mac
+	opcx ]1;]2
+	sec
+	rts
+	<<<

--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -2350,7 +2350,7 @@ relop         rep       $30
               pha
               pea       $8000                                                 ;locked page aligned
               psl       #$00
-              tll       $0902
+              _NewHandle
               plx
               ply
               bcs       :merr01
@@ -3813,7 +3813,7 @@ datop         rep       $30
 :dat2         lda       passnum
               beq       :d29
               psl       #:buffer
-              tll       $0F03
+              _ReadAsciiTime
 :d29          ldy       #$00
 ]lup          lda       :buffer,y
               and       #$7f
@@ -3844,7 +3844,7 @@ datop         rep       $30
 :dat4         lda       passnum
               beq       :d49
               psl       #:buffer
-              tll       $0F03
+              _ReadAsciiTime
 :d49          ldy       #$00
 ]lup          lda       :buffer,y
               and       #$7f
@@ -3864,7 +3864,7 @@ datop         rep       $30
               pha
               pha
               pha
-              tll       $0d03
+              _ReadTimeHex
               lda       1,s
               jsr       putbyte
               pla
@@ -3906,7 +3906,7 @@ datop         rep       $30
               pha
               pha
               pha
-              tll       $0d03
+              _ReadTimeHex
               lda       1,s
               and       #$ff
               jsr       :num
@@ -4297,7 +4297,7 @@ pauop         sep       $30
               rts
 
               mx        %00
-belop         tll       $2c03
+belop         _SysBeep
               lda       #$80
               trb       listflag+1
               clc

--- a/src/data/opdata.s
+++ b/src/data/opdata.s
@@ -29,7 +29,7 @@ opxcode        opco   'XC- ';psuedo.p6502;xcop1
                opco   'XC  ';psuedo.p6502;xcop
                opcl   'XBA ';onebyte.m65816;$EB
 opwcode        opco   'WDM ';m65816;wdmop
-               opcl   'WAI ';onebyte.m65c02;$CB
+               opcl   'WAI ';onebyte.m65C02;$CB
 opvcode        opcl   'VAR ';psuedo.p6502;varop
 opucode        opco   'USR ';psuedo.p6502;opcop                ;*** change this
                opcl   'USE ';psuedo.p6502;useop
@@ -42,9 +42,9 @@ optcode        opco   'TYX ';onebyte.m65816;$BB
                opco   'TTL ';psuedo.p6502;ttlop
                opco   'TSX ';onebyte.m6502;$BA
                opco   'TSC ';onebyte.m65816;$3B
-               opco   'TSB ';m65c02.general;tsbtbl
+               opco   'TSB ';m65C02.general;tsbtbl
                opco   'TSA ';onebyte.m65816;$3B
-               opco   'TRB ';m65c02.general;trbtbl
+               opco   'TRB ';m65C02.general;trbtbl
                opco   'TR  ';psuedo.p6502;trop
                opco   'TDC ';onebyte.m65816;$7B
                opco   'TDA ';onebyte.m65816;$7B
@@ -62,7 +62,7 @@ opscode        opco   'SYM ';psuedo.p6502;symop
                opco   'STX ';general.m6502.mX;stxtbl
                opco   'STRL';psuedo.p6502;strlop
                opco   'STR ';psuedo.p6502;strop
-               opco   'STP ';onebyte.m65c02;$db
+               opco   'STP ';onebyte.m65C02;$db
                opco   'STAL';general.long.m65816.mA;statbl
                opco   'STA ';general.m6502.mA;statbl
                opco   'SKP ';psuedo.p6502;skpop

--- a/src/data/qa.equates.s
+++ b/src/data/qa.equates.s
@@ -128,11 +128,11 @@ maxsymbols         =     $2000
 *  GSOS equates * call ID numbers
 
 * Set 'Class1' to $2000 to use Class 1 calls, $0000 for Class 0 calls
-
 prodos             =     $E100A8
 prodosIL           =     $E100B0
 inline             =     1                       ;stack or inline?
 
+                   do    0
 _Create            =     $0001.Class1
 _Destroy           =     $0002.Class1
 _OSShutdown        =     $2003                   ;class '1' only
@@ -190,4 +190,4 @@ _DRename           =     $2036                   ;class '1' only
 _GetStdRefNum      =     $2037                   ;class '1' only
 _GetRefNum         =     $2038                   ;class '1' only
 _GetRefInfo        =     $2039                   ;class '1' only
-
+                   fin

--- a/src/link/link.cmd.s
+++ b/src/link/link.cmd.s
@@ -1,10 +1,10 @@
-            put   link.vars
-            put   link.eval
-            put   linker.1
-            put   linker.2
-            put   link.errors
+*            put   link.vars
+*            put   link.eval
+*            put   linker.1
+*            put   linker.2
+*            put   link.errors
+            ovr   all
             asm   link.header
-            lnk   utility/qlinkgs.l
+            lnk   qlinkgs.l
             typ   exe
-            sav   utility/qlinkgs
-
+            sav   qlinkgs

--- a/src/link/link.eval.s
+++ b/src/link/link.eval.s
@@ -723,7 +723,7 @@ dodiv         php
               pha
               lda   xreg
               pha
-              tll   $0d0b
+              _LongDivide
               pla
               sta   xreg
               pla
@@ -759,7 +759,7 @@ domod         php
               pha
               lda   xreg
               pha
-              tll   $0d0b
+              _LongDivide
               pla
               pla
               pla

--- a/src/link/link.express.s
+++ b/src/link/link.express.s
@@ -1140,7 +1140,10 @@ indexj         da            5*2                     ; these indexes is crucial
 array          da            1,1,2,3,5,8,13,21,54,75,129,204
                da            323,527,850,1377,2227
 
+               do            0
+* Illegal relative address in line:
                err           *-array-34
+               fin
 
 seed           php
                rep           %00110000

--- a/src/link/link.express.s
+++ b/src/link/link.express.s
@@ -6,7 +6,7 @@ writeexp       php
                pha
                psl           #tempname+12
                pea           4
-               tll           $220b                   ;int2hex
+               _Int2Hex
 
                jsr           einitvars
                jcs           :errxit
@@ -178,7 +178,7 @@ buildexp       php
                pha
                pea           $8000
                psl           #$00
-               _newhandle
+               _NewHandle
                plx
                ply
                jcs           :errxit
@@ -801,7 +801,7 @@ writeseg       php
                rep           $30
                psl           #$00
                psl           seghdrhdl
-               _gethandlesize
+               _GetHandleSize
                pll           outrequest
                lda           seghdrptr
                sta           outbuffer
@@ -811,7 +811,7 @@ writeseg       php
                jcs           :err
                psl           #$00
                psl           segdatahdl
-               _gethandlesize
+               _GetHandleSize
                pll           outrequest
                lda           segdataptr
                sta           outbuffer
@@ -857,24 +857,24 @@ readseg        php
                pha
                pea           $0000
                psl           #$00
-               _newhandle
+               _NewHandle
                plx
                ply
                jcs           :errxit
                stx           seghdrhdl
                sty           seghdrhdl+2
 :resize        psl           seghdrhdl
-               _Hunlock
+               _HUnlock
                ldx           :offset
                pea           $00
                lda           segdata+headerlen,x
                pha
                psl           seghdrhdl
-               _sethandlesize
+               _SetHandleSize
                php
                pha
                psl           seghdrhdl
-               _Hlock
+               _HLock
                pla
                plp
                jcs           :errxit
@@ -906,14 +906,14 @@ readseg        php
                pha
                pea           $0000
                psl           #$00
-               _newhandle
+               _NewHandle
                plx
                ply
                jcs           :errxit
                stx           segdatahdl
                sty           segdatahdl+2
 :resize1       psl           segdatahdl
-               _Hunlock
+               _HUnlock
                ldx           :offset
                ldy           #$02
                lda           [seghdrptr]             ;get bytecnt
@@ -927,11 +927,11 @@ readseg        php
                lda           inrequest
                pha
                psl           segdatahdl
-               _sethandlesize
+               _SetHandleSize
                php
                pha
                psl           segdatahdl
-               _Hlock
+               _HLock
                pla
                plp
                jcs           :errxit

--- a/src/link/link.header.s
+++ b/src/link/link.header.s
@@ -11,9 +11,12 @@
 
 doexpress    =     $01
 
-             use   4/util.macs
-             use   qatools.macs
-             use   2/qa.equates
+             use   ../macros/builtin.macs
+             use   ../macros/qatools.macs
+             use   ../data/qa.equates
+
+             use   link.macs
+
 
              brl   start
 
@@ -497,5 +500,5 @@ tempbuff     ds    130
              lst   off
 
              typ   exe
-             sav   utility/qlinkgs.l
+             sav   qlinkgs.l
 

--- a/src/link/link.header.s
+++ b/src/link/link.header.s
@@ -87,7 +87,7 @@ start        php
              lda   userid
              ora   #linkmemid
              pha
-             _disposeall
+             _DisposeAll
              pla
              pld
              plb
@@ -240,7 +240,7 @@ doquicklink  php
              phy
              phx
              psl   #qtextend-qtext
-             tll   $2802              ;_PtrToHand
+             _PtrToHand
              psl   #quickname
              _QAGetPath
              lda   #^quickname

--- a/src/link/link.macs.s
+++ b/src/link/link.macs.s
@@ -1,0 +1,99 @@
+_DisposeHandle  MAC
+        tll     $1002
+        <<<
+_DisposeAll     MAC
+        tll     $1102
+        <<<
+_NewHandle      MAC
+        tll     $902
+        <<<
+_GetHandleSize  MAC
+        tll     $1802
+        <<<
+_SetHandleSize  MAC
+        tll     $1902
+        <<<
+_HLock  MAC
+        tll     $2002
+        <<<
+_HUnlock        MAC
+        tll     $2202
+        <<<
+
+_setmark        MAC
+        jsl     $e100a8
+        da      $16
+        adrl    ]1
+        <<<
+
+_getmark        MAC
+        jsl     $e100a8
+        da      $17
+        adrl    ]1
+        <<<
+
+_getprefix      MAC
+        jsl     $e100a8
+        da      $0a
+        adrl    ]1
+        <<<
+
+_create MAC
+        jsl     $e100a8
+        da      $01
+        adrl    ]1
+        <<<
+_destroy        MAC
+        jsl     $e100a8
+        da      $02
+        adrl    ]1
+        <<<
+_changepath     MAC
+        jsl     $e100a8
+        da      $04
+        adrl    ]1
+        <<<
+
+_setfileinfo    MAC
+        jsl     $e100a8
+        da      $05
+        adrl    ]1
+        <<<
+_getfileinfo    MAC
+        jsl     $e100a8
+        da      $06
+        adrl    ]1
+        <<<
+
+_open   MAC
+        jsl     $e100a8
+        da      $10
+        adrl    ]1
+        <<<
+_read   MAC
+        jsl     $e100a8
+        da      $12
+        adrl    ]1
+        <<<
+
+_write  MAC
+        jsl     $e100a8
+        da      $13
+        adrl    ]1
+        <<<
+_close  MAC
+        jsl     $e100a8
+        da      $14
+        adrl    ]1
+        <<<
+_seteof MAC
+        jsl     $e100a8
+        da      $18
+        adrl    ]1
+        <<<
+opc     mac
+        usr     ]1
+        dw      ]2
+        dw      ]3
+        <<<
+

--- a/src/link/link.macs.s
+++ b/src/link/link.macs.s
@@ -5,7 +5,7 @@ _DisposeAll     MAC
         tll     $1102
         <<<
 _NewHandle      MAC
-        tll     $902
+        tll     $0902
         <<<
 _GetHandleSize  MAC
         tll     $1802
@@ -18,6 +18,26 @@ _HLock  MAC
         <<<
 _HUnlock        MAC
         tll     $2202
+        <<<
+_LongDivide     MAC
+        tll     $0d0b
+        <<<
+_Int2Hex        MAC
+        tll     $220b
+        <<<
+_PtrToHand      MAC
+        tll     $2802
+        <<<
+_BlockMove      MAC
+        tll     $2b02
+        <<<
+
+_CreateResourceFile MAC
+        tll     $091e
+        <<<
+
+_ReadAsciiTime  MAC
+        tll     $0f03
         <<<
 
 _setmark        MAC

--- a/src/link/linker.1.s
+++ b/src/link/linker.1.s
@@ -9,7 +9,7 @@ link            php
                 pha
                 phy
                 phx
-                tll       $1802
+                _GetHandleSize
                 plx
                 ply
                 jcs       :err
@@ -57,15 +57,15 @@ link            php
                 lda       userid
                 ora       #linkmemid
                 pha
-                _disposeall
+                _DisposeAll
                 lda       userid
                 ora       #linkmemid+$100
                 pha
-                _disposeall
+                _DisposeAll
                 lda       userid
                 ora       #linkmemid+$200
                 pha
-                _disposeall
+                _DisposeAll
 
 :dxit           plp
                 rts
@@ -90,7 +90,7 @@ linker          php
                 pha
                 pea       $8000
                 psl       #$00
-                tll       $0902
+                _NewHandle
                 plx
                 ply
                 jcs       :memerr
@@ -106,7 +106,7 @@ linker          php
                 pha
                 pea       $8000
                 psl       #$00
-                tll       $0902
+                _NewHandle
                 plx
                 ply
                 jcs       :memerr
@@ -977,7 +977,7 @@ datop           lda       passnum
                 clc
                 rts
 :ok             psl       #:date+1
-                tll       $0F03                     ;_ReadAsciiTime
+                _ReadAsciiTime
                 psl       #:date
                 _QADrawString
                 lda       #$0d
@@ -1415,7 +1415,7 @@ impop           sec
                 sta       :handle+2
                 psl       #$00
                 psl       :handle
-                _gethandlesize
+                _GetHandlSize
                 pll       :aux
                 lda       :aux+2
                 jne       :toolarge
@@ -1425,13 +1425,13 @@ impop           sec
                 inc       :aux
                 inc       :aux
                 psl       :handle
-                _Hunlock
+                _HUnlock
                 psl       :aux
                 psl       :handle
-                _sethandlesize
+                _SetHandleSize
                 jcs       :doserr
                 psl       :handle
-                _Hlock
+                _HLock
                 dec       :aux
                 dec       :aux
                 lda       :handle
@@ -1459,7 +1459,7 @@ impop           sec
                 lda       segnum
                 sta       files+10,x
                 psl       :handle
-                _Hlock
+                _HLock
                 lda       :aux
                 clc
                 adc       reloffset
@@ -1650,7 +1650,7 @@ lnkop           sec
                 lda       segnum
                 sta       files+10,x
                 psl       :handle
-                _Hlock
+                _HLock
                 lda       :aux
                 clc
                 adc       reloffset
@@ -1812,10 +1812,10 @@ lnkop           sec
                 and       #$ff
                 sta       :byte
                 psl       :handle
-                _Hunlock
+                _HUnlock
                 psl       #$00
                 psl       :handle
-                _gethandlesize
+                _GetHandlSsize
                 pll       :size
                 lda       :more
                 clc
@@ -1825,11 +1825,11 @@ lnkop           sec
                 inc       :size+2
 :l1             psl       :size
                 psl       :handle
-                _sethandlesize
+                _SetHandleSize
                 php
                 pha
                 psl       :handle
-                _Hlock
+                _HLock
                 pla
                 plp
                 bcc       :deref
@@ -1867,7 +1867,7 @@ lnkop           sec
                 pea       $00
                 lda       :more
                 pha
-                tll       $2b02                     ;_Blockmove
+                _BlockMove
                 ldy       :aux
                 ldx       #$00
                 sep       $20
@@ -2137,7 +2137,7 @@ buildfinal
                 pha
                 lda       tempptr
                 pha
-                _Hlock
+                _HLock
                 ldy       #$02
                 lda       [tempptr]
                 tax
@@ -3623,7 +3623,7 @@ savop           lda       #$00
                 ora       compresshdl+2
                 beq       :plp
                 psl       compresshdl
-                _disposehandle
+                _DisposeHandle
                 stz       compresshdl
                 stz       compresshdl+2
 :plp            plp
@@ -3682,7 +3682,7 @@ compress        php
                 pha
                 pea       $8000
                 psl       #$00
-                tll       $0902
+                _NewHandle
                 plx
                 ply
                 jcs       :badcompress
@@ -4898,7 +4898,7 @@ saveseg         php
                 psl       :handle
                 _HUnlock
                 psl       :handle
-                _disposehandle
+                _DisposeHandle
                 plx
                 pla
                 plp
@@ -5460,15 +5460,15 @@ disposemem      php
                 lda       userid
                 ora       #linkmemid
                 pha
-                _disposeall
+                _DisposeAll
                 lda       userid
                 ora       #linkmemid+$100
                 pha
-                _disposeall
+                _DisposeAll
                 lda       userid
                 ora       #linkmemid+$200
                 pha
-                _disposeall
+                _DisposeAll
                 stz       linksymhdl
                 stz       linksymhdl+2
                 stz       globalhdl

--- a/src/link/linker.2.s
+++ b/src/link/linker.2.s
@@ -90,7 +90,7 @@ writerez1       php
                 lda         :outacc
                 pha
                 psl         #asmpath
-                tll         $091e                     ;_CreateResourceFile
+                _CreateResourceFile
                 jcs         :err
 :copy           psl         #$00
                 psl         #rezbuffsize
@@ -99,7 +99,7 @@ writerez1       php
                 pha
                 pea         $8000
                 psl         #$00
-                _newhandle
+                _NewHandle
                 plx
                 ply
                 jcs         :err
@@ -179,7 +179,7 @@ writerez1       php
                 ora         :handle+2
                 beq         :pla1
                 psl         :handle
-                _disposehandle
+                _DisposeHandle
                 stz         :handle
                 stz         :handle+2
 :pla1           pla
@@ -344,7 +344,7 @@ jumpentry       php
 :enter          jsr         newjmpentry
                 bcs         :sec
                 psl         jmphdl
-                _hlock
+                _HLock
                 lda         interseg
                 and         #$7fff
                 sta         jseg
@@ -378,7 +378,7 @@ jumpentry       php
                 sec
                 ror         dynamic
 :clc            psl         jmphdl
-                _hunlock
+                _HUnlock
                 plx
                 ply
                 plp
@@ -389,7 +389,7 @@ jumpentry       php
                 ora         jmphdl+2
                 beq         :sec1
                 psl         jmphdl
-                _hunlock
+                _HUnlock
 :sec1           pla
                 plx
                 ply
@@ -417,7 +417,7 @@ newjmpentry     php
                 pha
                 pea         $8000
                 psl         #$00
-                _newhandle
+                _NewHandle
                 plx
                 ply
                 jcs         :err
@@ -436,7 +436,7 @@ newjmpentry     php
                 _HUnlock
                 psl         #$00
                 psl         jmphdl
-                _gethandlesize
+                _GetHandleSize
                 pll         :size
                 lda         :size
                 clc
@@ -449,10 +449,10 @@ newjmpentry     php
                 bne         :toobig
                 psl         :size
                 psl         jmphdl
-                _sethandlesize
+                _SetHandleSize
                 bcs         :err
                 psl         jmphdl
-                _Hlock
+                _HLock
                 ldy         #$02
                 lda         [jmphdl]
                 sta         jmpptr
@@ -640,7 +640,7 @@ writejmpseg     php
 
 :omf3
                 psl         jmphdl
-                _hlock
+                _HLock
                 lda         jmphdl
                 sta         jmpptr
                 lda         jmphdl+2
@@ -652,7 +652,7 @@ writejmpseg     php
                 sta         :buffer+2
                 psl         #$00
                 psl         jmphdl
-                _gethandlesize
+                _GetHandleSize
                 pll         :request
 
                 lda         :request
@@ -1518,7 +1518,7 @@ newsegment      php
                 pha
                 pea         $00
                 psl         #$00
-                tll         $0902
+                _NewHandle
                 plx
                 ply
                 jcs         :sec1
@@ -1537,10 +1537,10 @@ newsegment      php
                 asl
                 pha
                 psl         segmenthdl
-                tll         $1902                     ;set handle size
+                _SetHandleSize
                 jcs         :sec1
                 psl         segmenthdl
-                _Hlock
+                _HLock
                 lda         segmenthdl
                 sta         segmentptr
                 lda         segmenthdl+2
@@ -1602,7 +1602,7 @@ inclablect      php
                 pha
                 pea         $8004                     ;page aligned/locked
                 psl         #$00
-                tll         $0902
+                _NewHandle
                 plx
                 ply
                 jcs         :sec
@@ -1650,7 +1650,7 @@ incasmlablect   php
                 pha
                 pea         $8004                     ;page aligned/locked
                 psl         #$00
-                tll         $0902
+                _NewHandle
                 plx
                 ply
                 jcs         :sec

--- a/src/macros/builtin.macs.S
+++ b/src/macros/builtin.macs.S
@@ -1,0 +1,148 @@
+* QAsm builtin macros
+
+tll	mac
+	ldx	#]1
+	jsl	$e10000
+	eom
+dos	mac
+	jsl	$e100a8
+	dw	]1
+	adrl	]2
+	eom
+tlc	mac
+	ldx	#]1
+	jsl	$e10000
+	bcc	*+4
+	brk	$00
+	eom
+psl	mac
+	if	#,]1
+	pea	^]1
+	pea	]1
+	else
+	lda	]1+2
+	pha
+	lda	]1
+	pha
+	fin
+	eom
+psw	mac
+	if	#,]1
+	pea	]1
+	else
+	lda	]1
+	pha
+	fin
+	eom
+pll	mac
+	pla
+	sta	]1
+	pla
+	sta	]1+2
+	eom
+plw	mac
+	pla
+	sta	]1
+	eom
+bsr	mac
+	per	*+4
+	bra	]1
+	eom
+bsrl	mac
+	per	*+5
+	brl	]1
+	eom
+jmi	mac
+	bpl	*+5
+	jmp	]1
+	eom
+jpl	mac
+	bmi	*+5
+	jmp	]1
+	eom
+jne	mac
+	beq	*+5
+	jmp	]1
+	eom
+jeq	mac
+	bne	*+5
+	jmp	]1
+	eom
+jlt	mac
+	bge	*+5
+	jmp	]1
+	eom
+jge	mac
+	blt	*+5
+	jmp	]1
+	eom
+ble	mac
+	blt	]1
+	beq	]1
+	eom
+jle	mac
+	beq	*+4
+	bge	*+5
+	jmp	]1
+	eom
+jcs	mac
+	bcc	*+5
+	jmp	]1
+	eom
+jcc	mac
+	bcs	*+5
+	jmp	]1
+	eom
+jvs	mac
+	bvc	*+5
+	jmp	]1
+	eom
+jvc	mac
+	bvs	*+5
+	jmp	]1
+	eom
+jmil	mac
+	bpl	*+6
+	jml	]1
+	eom
+jpll	mac
+	bmi	*+6
+	jmp	]1
+	eom
+jnel	mac
+	beq	*+6
+	jml	]1
+	eom
+jeql	mac
+	bne	*+6
+	jml	]1
+	eom
+jgel	mac
+	blt	*+6
+	jml	]1
+	eom
+jltl	mac
+	bge	*+6
+	jml	]1
+	eom
+jlel	mac
+	beq	*+4
+	bge	*+6
+	jml	]1
+	eom
+jcsl	mac
+	bcc	*+6
+	jml	]1
+	eom
+jccl	mac
+	bcs	*+6
+	jml	]1
+	eom
+jvsl	mac
+	bvc	*+6
+	jml	]1
+	eom
+jvcl	mac
+	bvs	*+6
+	jml	]1
+	eom

--- a/src/macros/qatools.macs.s
+++ b/src/macros/qatools.macs.s
@@ -1,0 +1,609 @@
+utool	mac
+	ldx #]1*256+1
+	jsl $E10008
+	<<<
+
+_QABootInit	mac		;_QABootInit()
+	utool	$01
+	<<<
+~QAStartup	MAC
+	psw	]1
+	psl	]2
+_QAStartup	mac		;_QAStartup(userid,modeflags/4)
+	utool	$02
+	<<<
+_QAShutdown	mac		;_QAShutdown()
+	utool	$03
+	<<<
+~QAVersion	MAC
+	pha
+_QAVersion	mac		;_QAVersion():versionnum
+	utool	$04
+	<<<
+_QAReset	mac		;_QAReset()
+	utool	$05
+	<<<
+~QAStatus	MAC
+	pha
+_QAStatus	mac		;_QAStatus():statflag
+	utool	$06
+	<<<
+~QADrawChar	MAC
+	phw	]1
+_QADrawChar	mac		;_QADrawChar(char)
+	utool	$09
+	<<<
+~QADrawString	MAC
+~QADrawStr	MAC
+	psl	]1
+_QADrawString	mac		;_QADrawString(@strptr)
+_QADrawStr	mac
+	utool	$0A
+	<<<
+~QAPrByte	MAC
+	psw	]1
+_QAPrByte	mac		;_QAPrByte(byteval)
+	utool	$0B
+	<<<
+~QAPrByteL	MAC
+	psw	]1
+_QAPrByteL	mac		;_QAPrByteL(hexval)
+	utool	$0C
+	<<<
+~QADrawDec	MAC
+	psl	]1
+	psw	]2
+	ps2	]3 <<< wrong
+_QADrawDec	mac		;_QADrawDec(longint/4,flags,fieldsize)
+	utool	$0D
+	<<<
+~QAKeyAvail	MAC
+	pha
+_QAKeyAvail	mac		;_QAKeyAvail():availflag
+	utool	$0E
+	<<<
+~QAGetChar	MAC
+	pha
+_QAGetChar	mac		;_QAGetChar():char (char in low/modifiers in high)
+	utool	$0F
+	<<<
+_QAGetLine	mac		;_QAGetLine(@linestr)
+	utool	$10
+	<<<
+~QASetParmHdl	MAC
+	psl	]1
+_QASetParmHdl	mac		;_QASetParmHdl(parmhandle)
+	utool	$11
+	<<<
+~QAGetParmHdl	MAC
+	pha
+	pha
+_QAGetParmHdl	mac		;_QAGetParmHdl():parmhandle
+	utool	$12
+	<<<
+~QASetCmdHdl	MAC
+	psl	]1
+	psw	]2
+_QASetCmdHdl	mac		;_QASetCmdHdl(commandhandle,numcmds)
+	utool	$13
+	<<<
+~QAGetCmdHdl	MAC
+	pha
+	pha
+	pha
+_QAGetCmdHdl	mac		;_QAGetCmdHdl():commandhandle,numcmds
+	utool	$14
+	<<<
+~QAReadTotalErrs	MAC
+	pha
+_QAReadTotalErrs	mac		;_QAReadTotalErrs():totalerrs
+	utool	$15
+	<<<
+~QAGetModeFlags	MAC
+	pha
+	pha
+_QAGetModeFlags	mac		;_QAGetModeFlags():modeflags/4
+	utool	$16
+	<<<
+~QASetModeFlags	MAC
+	psl	]1
+_QASetModeFlags	mac		;_QASetModeFlags(modeflags/4)
+	utool	$17
+	<<<
+_QALoadFile	mac		;_QALoadfile(@filename,filepos/4,length/4,@typelist,userid,address/4,memattrib):filehandle/4
+	utool	$18
+	<<<
+_QASaveFile	mac		;_QASavefile(filehandle/4,@filename,filetype,auxtype/4)
+	utool	$19
+	<<<
+~QASetCmdLine	MAC
+	psl	]1
+_QASetCmdLine	mac		;_QASetCmdLine(@strptr)
+	utool	$1A
+	<<<
+~QAGetCmdLine	MAC
+	psl	]1
+	psw	]2
+_QAGetCmdLine	mac		;_QAGetCmdLine(@strptr,maxlen)
+	utool	$1B
+	<<<
+~QAParseCmdLine	MAC
+	pha
+	pha
+	psl	]1
+_QAParseCmdLine	mac		;_QAParseCmdLine(@strptr):cmdid,cmdtype
+	utool	$1C
+	<<<
+~QAGetQuitFlag	MAC
+	pha
+_QAGetQuitFlag	mac		;_QAGetQuitFlag():quitflag
+	utool	$1D
+	<<<
+~QASetQuitFlag	MAC
+	psw	]1
+_QASetQuitFlag	mac		;_QASetQuitFlag(quitflag)
+	utool	$1E
+	<<<
+~QASetCmdTbl	MAC
+	psl	]1
+_QASetCmdTbl	mac		;_QASetCmdTbl(@cmdtbl)
+	utool	$1F
+	<<<
+~QAGetCmdTbl	MAC
+	pha
+	pha
+_QAGetCmdTbl	mac		;_QAGetCmdTbl():@cmdtbl
+	utool	$20
+	<<<
+~QAExecCommand	MAC
+	psw	]1
+	psw	]2
+_QAExecCommand	mac		;_QAExecCommand(cmdtype,cmdid)
+	utool	$21
+	<<<
+~QAGetMessagebyID	MAC
+	pha
+	pha
+	pha
+	psw	]1
+_QAGetMessagebyID	mac		;_QAGetMessagebyID(userid):message,subtype/4
+	utool	$22
+	<<<
+_QARun	mac		;_QARun()
+	utool	$23
+	<<<
+_QADispose	mac		;_QADispose()
+	utool	$24
+	<<<
+~QAShutdownID	MAC
+	psw	]1
+_QAShutdownID	mac		;_QAShutDownID(userid)
+	utool	$25
+	<<<
+~QACompile	MAC
+	psw	]1
+	psl	]2
+_QACompile	mac		;_QACompile(message,subtype/4)
+	utool	$26
+	<<<
+~QALink	MAC
+	psw	]1
+	psl	]2
+_QALink	mac		;_QALink(message,subtype/4)
+	utool	$27
+	<<<
+~QACompilerActive	MAC
+	pha
+_QACompilerActive	mac		;_QAComplierActive():activeflag
+	utool	$28
+	<<<
+~QALinkerActive	MAC
+	pha
+_QALinkerActive	mac		;_QALinkerActvie():activeflag
+	utool	$29
+	<<<
+~QAGetCompileID	MAC
+	pha
+_QAGetCompileID	mac		;_QAGetCompileID():compileID
+	utool	$2A
+	<<<
+~QASetCompileID	MAC
+	psw	]1
+_QASetCompileID	mac		;_QASetCompileID(compileID)
+	utool	$2B
+	<<<
+~QAGetLinkID	MAC
+	pha
+_QAGetLinkID	mac		;_QAGetLinkID():linkID
+	utool	$2C
+	<<<
+~QASetLinkID	MAC
+	psw	]1
+_QASetLinkID	mac		;_QASetLinkID(linkID)
+	utool	$2D
+	<<<
+~QAGetVector	MAC
+	pha
+	pha
+	psw	]1
+_QAGetVector	mac		;_QAGetVector(vect#):@address
+	utool	$2E
+	<<<
+~QASetVector	MAC
+	psw	]1
+	psl	]2
+_QASetVector	mac		;_QASetVector(vect#,@address)
+	utool	$2F
+	<<<
+_QAResetVectors	mac		;_QAResetVectors()
+	utool	$30
+	<<<
+~QAEvent	MAC
+	psl	]1
+	psw	]2
+_QAEvent	mac		;_QAEvent(@eventptr,taskflag)
+	utool	$31
+	<<<
+~QAGetCmdRecSize	MAC
+	pha
+_QAGetCmdRecSize	mac		;_QAGetCmdRecSize():recordsize
+	utool	$32
+	<<<
+~QATabToCol	MAC
+	psw	]1
+_QATabToCol	mac		;_QATabtoCol(columnnum)
+	utool	$33
+	<<<
+~QAErrorMsg	MAC
+	psw	]1
+_QAErrorMsg	mac		;_QAErrorMsg(ErrorCode)
+	utool	$34
+	<<<
+~QABarGraph	MAC
+	psw	]1
+	psl	]2
+_QABarGraph	mac		;_QABarGraph(percent,@Message)
+	utool	$35
+	<<<
+~QAConvertPath	MAC
+	psl	]1
+	psl	]2
+_QAConvertPath	mac		;_QAConvertPath(@oldpath,@newpath)
+	utool	$36
+	<<<
+~QATyp2Txt	MAC
+	psw	]1
+	psl	]2
+_QATyp2Txt	mac
+_QAConvertTyp2Txt	mac		;_QAConvertTyp2Txt(filetype,@typestr)
+	utool	$37
+	<<<
+~QATxt2Typ	MAC
+	pha
+	psl	]1
+_QATxt2Typ	mac
+_QAConvertTxt2Typ	mac		;_QAConvertTxt2Typ(@typestr):type
+	utool	$38
+	<<<
+~QAReadDir	MAC
+	psl	]1
+	psl	]2
+	psw	]3
+_QAReadDir	mac		;_QAReadDir(@pathname,@doroutine,flags)
+	utool	$39
+	<<<
+~QAInitWildcard	MAC
+	psl	]1
+	psw	]2
+	psl	]3
+	psw	]4
+	psl	]5
+_QAInitWildcard	mac		;_QAInitWildcard(@wcstr,ft,aux/4,ftmask,auxmask/4)
+	utool	$3A
+	<<<
+_QAUndefined	mac		;_QAUndefined()
+	utool	$3B
+	<<<
+_QAInitTotalErrs	mac		;_QAInitTotalErrs()
+	utool	$3C
+	<<<
+_QAIncTotalErrs	mac		;_QAIncTotalErrs()
+	utool	$3D
+	<<<
+~QAGetTotalErrs	MAC
+	pha
+_QAGetTotalErrs	mac		;_QAGetTotalErrs():totalerrs
+	utool	$3E
+	<<<
+~QAGetCancelFlag	MAC
+	pha
+_QAGetCancelFlag	mac		;_QAGetCancelFlag():cancelflag
+	utool	$3F
+	<<<
+~QASetCancelFlag	MAC
+	psw	]1
+_QASetCancelFlag	mac		;_QASetCancelFlag(cancelflag)
+	utool	$40
+	<<<
+_QAStartTiming	mac		;_QAStartTiming()
+	utool	$41
+	<<<
+~QAEndTiming	MAC
+	pha
+	pha
+	pha
+_QAEndTiming	mac		;_QAEndTiming():hours,minutes,seconds
+	utool	$42
+	<<<
+~QAGetSymTable	MAC ;; was missing nextLabel.
+	pha
+	pha
+	pha
+	pha
+	pha
+	pha
+	pha
+_QAGetSymTable	mac		;_QAGetSymTable():@table,symhandle/4,numlabels,nextLabel/4
+	utool	$43
+	<<<
+~QASetSymTable	MAC ;; was missing nextLabel
+	psl	]1
+	psl	]2
+	psw	]3
+	psl	]4
+_QASetSymTable	mac		;_QASetSymTable(@table,symhandle/4,numlabels,nextLabel/4)
+	utool	$44
+	<<<
+~QASetPath	MAC
+	psl	]1
+_QASetPath	mac		;_QASetPath(@pathname)
+	utool	$45
+	<<<
+~QAGetPath	MAC
+	psl	]1
+_QAGetPath	mac		;_QAGetPath(@pathname)
+	utool	$46
+	<<<
+~QAGetObjType	MAC
+	pha
+_QAGetObjType	mac		;_QAGetObjType():type
+	utool	$47
+	<<<
+~QASetObjType	MAC
+	psw	]1
+_QASetObjType	mac		;_QASetObjType(type)
+	utool	$48
+	<<<
+~QAGetObjPath	MAC
+	psl	]1
+_QAGetObjPath	mac		;_QAGetObjPath(@pathname)
+	utool	$49
+	<<<
+~QASetObjPath	MAC
+	psl	]1
+_QASetObjPath	mac		;_QASetObjPath(@pathname)
+	utool	$4A
+	<<<
+~QACallUSR	MAC
+	pha
+	psw	]1
+	psl	]2
+_QACallUSR	mac		;_QACallUSR(opcode,@operand):handled
+	utool	$4B
+	<<<
+~QACallUser	MAC
+	psw	]1
+	psw	]2
+	psl	]3
+	psl	]4
+_QACallUser	mac		;_QACallUser(rngstart,rngend,texthandle/4,textlen/4)
+	utool	$4C
+	<<<
+~QAGoEval	MAC
+	pha
+	pha
+	psl	]1
+	psw	]2
+_QAGoEVAL	mac		;_QAGoEVAL(@operand,offset):value/4
+	utool	$4D
+	<<<
+~QAGoPutByte	MAC
+	psw	]1
+_QAGoPutByte	mac		;_QAGoPutByte(byte)
+	utool	$4E
+	<<<
+~QAGoPutOpcode	MAC
+	psw	]1
+_QAGoPutOpcode	mac		;_QAGoPutOpcode(opcodebyte)
+	utool	$4F
+	<<<
+_QAGoRelcorrect	mac		;_QAGoRelcorrect()
+	utool	$50
+	<<<
+~QADrawErrChar	MAC
+	psw	]1
+_QADrawErrChar	mac		;_QADrawErrChar(char)
+	utool	$51
+	<<<
+~QADrawErrStr	MAC
+	psl	]1
+_QADrawErrStr	mac
+_QADrawErrString	mac		;_QADrawErrString(@strptr)
+	utool	$52
+	<<<
+~QAGetWindow	MAC
+	pha <<<< wrong!
+	pha
+_QAGetWindow	mac		;_QAGetWindow():windowtype
+	utool	$53
+	<<<
+~QASetWindow	MAC
+	psl	]1 <<< wrong!
+_QASetWindow	mac		;_QASetWindow(windowtype)
+	utool	$54
+	<<<
+~QAGetShellID	MAC
+	pha
+_QAGetShellID	mac		;_QAGetShellID():userid
+	utool	$55
+	<<<
+~QASetShellID	MAC
+	psw	]1
+_QASetShellID	mac		;_QASetShellID(userid)
+	utool	$56
+	<<<
+~QAGotoXY	MAC
+	psw	]1
+	psw	]2
+_QAGotoXY	mac		;_QAGotoXY(X,Y)
+	utool	$57
+	<<<
+~QAGetXY	MAC
+	pha
+	pha
+_QAGetXY	mac		;_QAGetXY():X,Y
+	utool	$58
+	<<<
+~QAPrNibble	MAC
+	psw	]1
+_QAPrNibble	mac		;_QAPrNibble(nibval)
+	utool	$59
+	<<<
+~QADrawHex	MAC
+	psl	]1
+	psw	]2
+	psw	]3
+_QADrawHex	mac		;_QADrawHex(hexval/4,flags,fieldsize)
+	utool	$5A
+	<<<
+~QADrawCStr	mac
+~QADrawCString	mac
+	psl	]1
+_QADrawCStr	mac
+_QADrawCString	mac
+_QADrawBlock	mac		;_QADrawBlock(@CBlock)
+	utool	$5B
+	<<<
+~QADrawErrCStr	MAC
+	psl	]1
+_QADrawErrCStr	mac
+_QADrawErrBlock	mac		;_QADrawErrBlock(@CBlock)
+	utool	$5C
+	<<<
+~QADrawCharX	MAC
+	psw	]1
+	psw	]2
+_QADrawCharX	mac		;_QADrawCharX(char,count)
+	utool	$5D
+	<<<
+~QADrawECharX	MAC
+	psw	]1
+	psw	]2
+_QADrawECharX	mac		;_QADrawECharX(char,count)
+	utool	$5E
+	<<<
+~QAGetLaunch	MAC
+	pha
+	pha
+	pha
+_QAGetLaunch	mac		;_QAGetLaunch():@path,flags
+	utool	$5F
+	<<<
+~QASetLaunch	MAC
+	psl	]1
+	psw	]2
+_QASetLaunch	mac		;_QASetLaunch(@path,flags)
+	utool	$60
+	<<<
+~QAGetWord	MAC
+	pha
+	pha
+	psl	]1
+	psw	]2
+	psw	]3
+_QAGetWord	mac		;_QAGetWord(@Text,Offset,MaxLen):BegOffset,EndOffset
+	utool	$61
+	<<<
+~QADateTime	mac
+	psl	]1
+	psw	]2
+_QADateTime	mac		;_QADateTime(@Date,flags)
+	utool	$62
+	<<<
+_QADrawCR	mac		;_QADrawCR()
+	utool	$63
+	<<<
+_QADrawSpace	mac		;_QADrawSpace()
+	utool	$64
+	<<<
+~QADrawVersion	mac
+	psl	]1
+_QADrawVersion	mac		;_QADrawVersion(Version/4)
+	utool	$65
+	<<<
+~QADrawBox	MAC
+	pha
+	pha
+	psw	]1
+	psw	]2
+	psw	]3
+	psw	]4
+_QADrawBox	MAC		;_QADrawBox(x,y,width,height):buffhdl
+	utool	$66
+	<<<
+~QAEraseBox	MAC
+	psl	]1
+_QAEraseBox	MAC		;_QAEraseBox(buffhdl)
+	utool	$67
+	<<<
+~QAConvertStr	MAC
+	pha
+	psl	]1
+	psl	]2
+	psw	]3
+_QAConvertStr	MAC		;_QAConvertStr(@string/class.1,@buffer/class.1,cmdcode):rtncode
+	utool	$68
+	<<<
+~QADrawStrL	MAC
+	psl	]1
+_QADrawStrL	MAC		;_QADrawStrL(@string/class.1)
+	utool	$69
+	<<<
+~QADrawErrStrL	MAC
+	psl	]1
+_QADrawErrStrL	MAC		;_QADrawErrStrL(@strptr/class.1)
+	utool	$6A
+	<<<
+~QAGetKeyAdrs	MAC
+	pha
+	pha
+_QAGetKeyAdrs	MAC		;_QAGetKeyAdrs():keyaddress/4
+	utool	$6B
+	<<<
+~QANextLine	MAC
+	pha
+	pha
+	psl	]1
+	psw	]2
+	psw	]3
+_QANextLine	mac		;_QANextLine(@Text,Offset,MaxLen):NewLineOffset
+	utool	$6C
+	<<<
+_QAClearKey	MAC		;_QAClearKey()
+	utool	$6D
+	<<<
+_QAParseWord	MAC		;_QAParseWord(???):???
+	utool	$6E
+	<<<
+
+
+
+*utool	mac
+*	ldx	#]1*256+ToolNum
+*	do	userorsys
+*	jsl	$E10008
+*	else
+*	jsl	$E10000
+*	fin
+*	<<<
+


### PR DESCRIPTION
tweaks to enable qasm (gs) and qlink (gs) to self assemble.

Also use nicely named tool macros instead of `tll $xxxx`  (which accounts for most of the changes).

