### PR TITLE
fix y2k dat display.

### DIFF
--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -3941,7 +3941,11 @@ datop         rep       $30
               pla
               xba
               and       #$ff
-              jsr       :num
+]y2k          cmp       #100
+              bcc       :yy
+              sbc       #100
+              bne       ]y2k
+:yy           jsr       :num
               sta       :buffer1+7
               lda       1,s
               and       #$ff


### PR DESCRIPTION
`_ReadTimeHex` returns the year as an offset from 1900, so 2020 is 120, which overflows ('0' + 12 is ascii '<')

subtract 100, repeatedly, until it fits in 2 digits.  Should last into 2100 and beyond.

Fixes #33

dat.s:
```
    dat
````

before:
```
Assembling test/dat.S

                      1               06-JAN-<0   7:42:05 PM
                      2 
```

after:
```
Assembling test/dat.S

                      1               06-JAN-20   7:42:11 PM
                      2 
```
