### PR TITLE
reset dumor to 0, not $8000, at DEND. (qasm iigs)

### DIFF
--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -642,8 +642,7 @@ dendop        lda       #dumflag
               rts
 :ok           bit       macflag-1
               bmi       :bad
-              lda       #$8000
-              sta       dumor
+              stz       dumor
               lda       dumorg
               sta       objptr
               lda       dumorg+$2


### PR DESCRIPTION
should fix a bug where DUM * (or DUM label) generates absolute values.

Before:
```
Assembling test/dumdum.1.S

                      1 
                      3              sym               
                      4              rel               
                      5 
                      6              dum  *            
                      7 xx           ds   2            
                      8              dend              
                      9 
                      10             dum  *            
                      11 yy          ds   2            
                      12             dend              
                      13 
                      14 *
                      15 *  both xx and yy should be relative values.
                      16 *
01 R      XX                $008000  0000 0000
01 R      YY                $008000  8000 0001 <<<< ABSOLUTE VALUE

End of QuickASM assembly. 0 bytes, 0 errors, 16 lines, 2 symbols.

Elapsed time = < 1 second.
```
After:
```
Assembling test/dumdum.1.S

                      1 
                      3              sym               
                      4              rel               
                      5 
                      6              dum  *            
                      7 xx           ds   2            
                      8              dend              
                      9 
                      10             dum  *            
                      11 yy          ds   2            
                      12             dend              
                      13 
                      14 *
                      15 *  both xx and yy should be relative values.
                      16 *
01 R      XX                $008000  0000 0000
01 R      YY                $008000  0000 0001

End of QuickASM assembly. 0 bytes, 0 errors, 16 lines, 2 symbols.

Elapsed time = < 1 second.
```

($8000 being the absolute value bit)

The actual problem is from QATools which uses absolute DUM segments for stack definitions but has a relative DUM segment at the end for variables.  Those labels generate absolute values so bad things happen.