### PR TITLE
qasm iigs: only add .S extension as necessary

### DIFF
--- a/src/asm/asm.header.s
+++ b/src/asm/asm.header.s
@@ -125,6 +125,7 @@ txtfile     php
             dey
             bpl   ]lup
             rep   $30
+            jsr   append_dots
 
             psl   #$00
             psl   #filename
@@ -215,24 +216,8 @@ cmdline     php
 :set        txa
             sta   filename
             rep   $30
-            lda   filename
-            and   #$ff
-            cmp   #62
-            bge   :nosuff
-            tax
-            lda   filename,x
-            and   #$7f
-            cmp   #'/'
-            beq   :nosuff
-            inx
-            lda   #'.S'
-            sta   filename,x
-            inx
-            txa
-            sep   $20
-            sta   filename
+            jsr   append_dots
 
-:nosuff     rep   $30
             psl   #$00
             psl   #filename
             psl   #$00              ;filepos
@@ -274,6 +259,35 @@ cmdline     php
             cmpl  :one
             rts
 :one        dw    $01
+
+
+append_dots
+            lda   filename
+            and   #$ff
+            beq   :rts
+            cmp   #62
+            bcs   :rts
+            tax
+            lda   #'.S'
+            sta   filename+1,x
+            sep   $30
+            lda   filename,x
+            cmp   #'/'
+            beq   :rts
+            cmp   #':'
+            beq   :rts
+            and   #$df
+            cmp   #'S'
+            bne   :append
+            lda   filename-1,x
+            cmp   #'.'
+            beq   :rts
+:append     inx
+            inx
+            stx filename
+
+:rts        rep   $30
+            rts
 
 asmstr      str   0d,'Assembling'
 

--- a/src/link/link.header.s
+++ b/src/link/link.header.s
@@ -156,26 +156,10 @@ txtfile      php
              sta   filename,x
              dey
              bpl   ]lup
-             lda   filename
-             cmp   #62
-             bge   :nosufx
-             tax
-             lda   filename,x
-             cmp   #'/'
-             beq   :nosufx
-             cmp   #':'
-             beq   :nosufx
 
-             inc   filename
-             inc   filename
-             inx
-             lda   #'.'
-             sta   filename,x
-             inx
-             lda   #'S'
-             sta   filename,x
+             rep   $30
+             jsr   append_dots
 
-:nosufx      rep   $30
              psl   #$00
              psl   #filename
              psl   #$00               ;filepos
@@ -378,26 +362,8 @@ cmdline      php
 :set         txa
              sta   filename
              rep   $30
-             lda   filename
-             and   #$ff
-             cmp   #62
-             bge   :nosuff
-             tax
-             lda   filename,x
-             and   #$7f
-             cmp   #'/'
-             beq   :nosuff
-             cmp   #':'
-             beq   :nosuff
-             inx
-             lda   #'.S'
-             sta   filename,x
-             inx
-             txa
-             sep   $20
-             sta   filename
+             jsr   append_dots
 
-:nosuff      rep   $30
              psl   #$00
              psl   #filename
              psl   #$00               ;filepos
@@ -439,6 +405,35 @@ cmdline      php
 :one         dw    $01
 
 linkstr      str   0d,'Linking'
+
+
+append_dots
+            lda   filename
+            and   #$ff
+            beq   :rts
+            cmp   #62
+            bcs   :rts
+            tax
+            lda   #'.S'
+            sta   filename+1,x
+            sep   $30
+            lda   filename,x
+            cmp   #'/'
+            beq   :rts
+            cmp   #':'
+            beq   :rts
+            and   #$df
+            cmp   #'S'
+            bne   :append
+            lda   filename-1,x
+            cmp   #'.'
+            beq   :rts
+:append     inx
+            inx
+            stx filename
+
+:rts        rep   $30
+            rts
 
 
 prbytel

--- a/src/link/linker.2.s
+++ b/src/link/linker.2.s
@@ -1738,23 +1738,8 @@ getpath         php
 :len            stx         asmpath
                 lda         :sflag
                 beq         :plp
-                lda         asmpath
-                cmp         #63
-                bge         :plp
-                tax
-                lda         asmpath,x
-                and         #$7f
-                cmp         #'/'
-                beq         :plp
-                lda         asmpath
-                inc
-                inc
-                sta         asmpath
-                lda         #'.'
-                sta         asmpath+1,x
-                inx
-                lda         #'S'
-                sta         asmpath+1,x
+                jsr         asmpath_s
+
 :plp            sep         $30
                 lda         asmpath
                 beq         :syn
@@ -1839,7 +1824,32 @@ getpath         php
 :pfxparm        dw          $00
                 adrl        asmpath
 
+asmpath_s       mx         %11
+                ldx         asmpath
+                beq         :rts
+                cpx         #63
+                bcs         :rts
 
+                lda         asmpath,x
+                cmp         #'/'
+                beq         :rts
+                cmp         #':'
+                beq         :rts
+                and         #$df
+                cmp         #'S'
+                bne         :append
+                lda         asmpath-1,x
+                cmp         #'.'
+                beq         :rts
+
+:append         inx
+                lda         #'.'
+                sta         asmpath,x
+                inx
+                lda         #'S'
+                sta         asmpath,x
+                stx         asmpath
+:rts            rts
 
 
 converttable


### PR DESCRIPTION
modifies the asm command line, linker command line, and linker ASM/PUT/IF opcodes to only append a .S suffix if it's not already present.

this is more consistent with Merlin 16+ and less surprising for people who use the command-line asm or link commands.