### PR TITLE
(qasm iigs) - add back error checking disabled for relative value bug

### DIFF
--- a/src/asm/asm.header.s
+++ b/src/asm/asm.header.s
@@ -402,9 +402,7 @@ indexj      da    5*2               ; these indexes is crucial
 array       da    1,1,2,3,5,8,13,21,54,75,129,204
             da    323,527,850,1377,2227
 
-            do    0
             err   *-array-34
-            fin
 
 *=================================================
 * SEED seeds generator from 16 bit contents of AXY

--- a/src/link/link.express.s
+++ b/src/link/link.express.s
@@ -1140,10 +1140,7 @@ indexj         da            5*2                     ; these indexes is crucial
 array          da            1,1,2,3,5,8,13,21,54,75,129,204
                da            323,527,850,1377,2227
 
-               do            0
-* Illegal relative address in line:
                err           *-array-34
-               fin
 
 seed           php
                rep           %00110000

--- a/src/link/linker.1.s
+++ b/src/link/linker.1.s
@@ -1415,7 +1415,7 @@ impop           sec
                 sta       :handle+2
                 psl       #$00
                 psl       :handle
-                _GetHandlSize
+                _GetHandleSize
                 pll       :aux
                 lda       :aux+2
                 jne       :toolarge
@@ -1815,7 +1815,7 @@ lnkop           sec
                 _HUnlock
                 psl       #$00
                 psl       :handle
-                _GetHandlSsize
+                _GetHandleSize
                 pll       :size
                 lda       :more
                 clc


### PR DESCRIPTION
adds back error checking which was previously disabled due to the illegal relative value bug.

also fixes a couple tool macro typos that slipped in before