### PR TITLE
(qasm iigs) ent label-list operand

### DIFF
--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -1673,8 +1673,6 @@ exdop
 entop
 ]len          equ       workspace
 
-              lda       passnum
-              bne       :xit
               lda       macflag
               bit       #%01100000
               beq       :nomac
@@ -1684,6 +1682,9 @@ entop
 :nomac
               lda       linelable
               bmi       :group
+* label ent - first pass only.
+              ldx       passnum
+              bne       :xit
               asl
               asl
               tay
@@ -1762,7 +1763,10 @@ entop
               trb       orgor
               jmp       :xit
 
+* ent label[,label] - second pass only.
 :group1       rep       $30
+              ldx       passnum
+              beq       :xit
               sep       $20
               ldy       #$FFFF
 ]lup          iny
@@ -1806,12 +1810,9 @@ entop
               lda       #$ffff
               sta       fllast
               jsr       findlable
-              bcs       :or
-              jsr       insertlable
-              stz       fllast
-              dec       fllast
-              jcs       :gerr1
-:or           stz       :offset
+              bcc       :gerr3
+
+              stz       :offset
               ldy       #26                                                   ;point to type
               lda       [lableptr],y
               and       #macvarbit.externalbit.macrobit.variablebit.localbit
@@ -1836,6 +1837,9 @@ entop
               rts
 :gerr         rep       $30
               lda       #badlable
+              jmp       :gerr1
+:gerr3        rep       $30
+              lda       #undeflable
               jmp       :gerr1
 :gerr2        rep       $30
               lda       #duplable


### PR DESCRIPTION
 should only execute on the second pass, after all labels are defined.

previously, `    ENT label[,label]` executes on the first pass and creates a new label entry for undefined (ie, forward or missing) labels.  When the label is defined it overwrites the `entrybit` and doesn't get exported in the REL file.  Additionally, non-existent symbols ARE exported in the REL file.


This modifies ENT processing so the label list form is processed on the second pass, after all symbols have been defined naturally.

```
label	ENT			; first pass only
	ENT ON/OFF		; first and second pass
	ENT label,...		; second pass only
```

(on/off are processed on both passes since it's harmless (and less work) to do so)

Before:
```
                     1              rel               
                     3              sym               
                     4 
                     5 aaa          ent               
008000: EA           6              nop               
                     7              ent  on           
                     8 bbb                            
008001: EA           9              nop               
                     10             ent  off          
                     11 
                     12             ent  ccc,ddd      
                     13 ccc                           
008002: EA           14             nop               
                     15 
            =123456  16 equate      =    $123456      
                     17             ent  equate       
                     18 

Object saved as ent.l,A$0003,L$0024,LNK
                     20 
01 R      AAA               $008000  4000 0000
01 R      BBB               $008001  4000 0001
01 R      CCC               $008002  0000 0002
01 R      DDD               $008001  4000 0003
01 R      EQUATE            $123456  C008 0004
```
($4000 is the ENTry bit) DDD is exported but CCC is not.

After:
```
                     1              rel               
                     3              sym               
                     4    
                     5    aaa       ent               
008000: EA           6              nop               
                     7              ent  on           
                     8    bbb                         
008001: EA           9              nop               
                     10             ent  off          
                     11   

Undefined label in line: 12.
                     12             ent  ccc,ddd      

                     13   ccc                         
008002: EA           14             nop               
                     15   
            =123456  16   equate    =    $123456      
                     17             ent  equate       
                     18 
```

Errors out due to undefined symbol

```
                     1              rel               
                     3              sym               
                     4    
                     5    aaa       ent               
008000: EA           6              nop               
                     7              ent  on           
                     8    bbb                         
008001: EA           9              nop               
                     10             ent  off          
                     11   
                     12             ent  ccc          ;,ddd
                     13   ccc                         
008002: EA           14             nop               
                     15   
            =123456  16   equate    =    $123456      
                     17             ent  equate       
                     18   

Object saved as ent.l,A$0003,L$0024,LNK
                     20   
01 R      AAA               $008000  4000 0000
01 R      BBB               $008001  4000 0001
01 R      CCC               $008002  4000 0002
01 R      EQUATE            $123456  C008 0003
```

All symbols exported appropriately.

