### PR TITLE
symbol table needs to be no-cross-bank

### DIFF
--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -1603,7 +1603,7 @@ inclablect   php
              lda   userid
              ora   #asmmemid
              pha
-             pea   $8004                               ;page aligned/locked
+             pea   $8014                               ;page aligned/locked/nocross
              psl   #$00
              _NewHandle
              plx

--- a/src/link/linker.2.s
+++ b/src/link/linker.2.s
@@ -1600,7 +1600,7 @@ inclablect      php
                 ldal        userid
                 ora         #linkmemid
                 pha
-                pea         $8004                     ;page aligned/locked
+                pea         $8014                     ;page aligned/locked/nocross
                 psl         #$00
                 _NewHandle
                 plx
@@ -1648,7 +1648,7 @@ incasmlablect   php
                 lda         userid
                 ora         #linkmemid+$100
                 pha
-                pea         $8004                     ;page aligned/locked
+                pea         $8014                     ;page aligned/locked/nocross
                 psl         #$00
                 _NewHandle
                 plx


### PR DESCRIPTION
 since qasm uses MVN to copy entries into it (and MVN won't cross banks)