### PR TITLE
Update label/symbol size from 15 to 31.

### DIFF
--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -201,7 +201,7 @@ asm          php
              plx
              cmp   #' '+1
              blt   :glabdone
-:cpx         cpx   #$0f
+:cpx         cpx   #lab_size
              bge   :gliny
              sta   labstr+1,x
              inx
@@ -210,9 +210,9 @@ asm          php
 :sjmp        jmp   :savlen
 :cjmp        jmp   :comment
 
-:glabdone    cpx   #$10
+:glabdone    cpx   #lab_size+1
              blt   :gl2
-             ldx   #$0f
+             ldx   #lab_size
 :gl2         stx   labstr
              cmp   #' '
              blt   :sjmp
@@ -1599,7 +1599,7 @@ inclablect   php
              and   #%11111111
              bne   :normal
              psl   #$00
-             psl   #$2000
+             psl   #sym_size*256
              lda   userid
              ora   #asmmemid
              pha
@@ -1626,7 +1626,7 @@ inclablect   php
              jmp   :rts
 :normal      lda   nextlableptr
              clc
-             adc   #32
+             adc   #sym_size
              sta   nextlableptr
              bcc   :rts
              inc   nextlableptr+2
@@ -1858,9 +1858,9 @@ domacros     php                                       ;enter with $00 in A to s
              cmp   #$00
              bne   :nofind
              ldx   opcode
-             cpx   #$10
+             cpx   #lab_size+1
              blt   :move
-             ldx   #$0f
+             ldx   #lab_size
 :move        lda   opcode,x
              sta   labstr,x
              dex
@@ -1874,7 +1874,7 @@ domacros     php                                       ;enter with $00 in A to s
              bcc   :builtin                            ;not found so try built in macs
              bcc   :bad
              rep   $20
-             ldy   #26
+             ldy   #o_labtype
              lda   [lableptr],y
              and   #$8004
              cmp   #$8004
@@ -2319,7 +2319,7 @@ domac1       php
              sty   macflag
              bcc   :restore                            ;notfound
              rep   $20
-             ldy   #26
+             ldy   #o_labtype
              lda   [lableptr],y
              and   #$8004
              cmp   #$8004
@@ -3019,12 +3019,12 @@ relcorrect   php
              lda   [lableptr1],y
              sta   lableptr+2
              ldx   #$00
-             ldy   #26
+             ldy   #o_labtype
              lda   [lableptr],y
              and   #$10
              beq   :noext
              tsb   :flags
-             ldy   #22
+             ldy   #o_labprev
              lda   [lableptr],y
              sta   :refnum
              lda   #$8000
@@ -3215,7 +3215,7 @@ define       ldy   #$00
              sta   fllast
              jsr   findlable
              bcc   :p0insert
-             ldy   #26
+             ldy   #o_labtype
              lda   [lableptr],y
              bit   #variablebit
              bne   :p0var
@@ -3224,15 +3224,15 @@ define       ldy   #$00
              bit   macflag-1
              bvs   :p0insert
              jmp   :dup
-:p0var       ldy   #16
+:p0var       ldy   #o_labnum
              lda   [lableptr],y
              sta   linelable
-             ldy   #28
+             ldy   #o_labval
              lda   [lableptr],y
              sta   varval
              lda   objptr
              sta   [lableptr],y
-             ldy   #30
+             ldy   #o_labval+2
              lda   [lableptr],y
              sta   varval+2
              lda   objptr+2
@@ -3244,7 +3244,7 @@ define       ldy   #$00
              sta   labval+2
              jsr   insertlable
              bcs   :err                                ;error returned in A
-             ldy   #16
+             ldy   #o_labnum
              lda   [lableptr],y
              sta   linelable
              stz   varval
@@ -3257,39 +3257,39 @@ define       ldy   #$00
              sta   fllast
              jsr   findlable
              bcc   :undef                              ;not found on second pass
-             ldy   #16
+             ldy   #o_labnum
              lda   [lableptr],y
              sta   linelable
-             ldy   #26
+             ldy   #o_labtype
              lda   [lableptr],y
              bit   #variablebit
              bne   :p1var
              bit   #$20.$10.$08.$04.$01.linkerbit      ;ext,macvar,macro,
              beq   :checkmis                           ;                    locals, or linkerequ's
              jmp   :noerr
-:p1var       ldy   #28
+:p1var       ldy   #o_labval
              lda   [lableptr],y
              sta   varval
              lda   objptr
              sta   [lableptr],y
-             ldy   #30
+             ldy   #o_labval+2
              lda   [lableptr],y
              sta   varval+2
              lda   objptr+2
              sta   [lableptr],y
              jmp   :noerr
-:checkmis    ldy   #28
+:checkmis    ldy   #o_labval
              lda   [lableptr],y
              cmp   objptr
              bne   :misal
-             ldy   #30
+             ldy   #o_labval+2
              lda   [lableptr],y
              cmp   objptr+2
              beq   :noerr
-:misal       ldy   #28
+:misal       ldy   #o_labval
              lda   [lableptr],y                        ;reset object pointer so we don't
              sta   objptr                              ;generate more misalign errors
-             ldy   #30
+             ldy   #o_labval+2
              lda   [lableptr],y
              sta   objptr+$2
              pea   #misalignment
@@ -3302,13 +3302,13 @@ define       ldy   #$00
 :xit         rep   $30
              bit   linelable
              bmi   :geterr
-             ldy   #26
+             ldy   #o_labtype
              lda   [lableptr],y
              and   #%111111.linkerbit                  ;no macvars,externals,equates,macros,variables,
              bne   :geterr                             ;locals or linkerequ's...
              lda   globlab
              sta   oldglob
-             ldy   #16
+             ldy   #o_labnum
              lda   [lableptr],y
              sta   globlab
              lda   #$0080
@@ -3382,7 +3382,7 @@ findlable
              iny
              lda   [lableptr1],y
              sta   lableptr+2
-             ldy   #24
+             ldy   #o_lablocal
              lda   [lableptr],y
              bmi   :notfound                           ;none defined
              sta   ]pos
@@ -3406,12 +3406,12 @@ findlable
              sta   lableptr+2
              stz   ]offset
              lda   [lableptr]
-             and   #$0f
+             and   #label_mask
              sta   ]len2
              sep   $20
              ldx   #$02                                ;start at byte 2
              txy
-]lup1        cpx   #$10
+]lup1        cpx   #lab_size+1
              bge   :movefound
              cpx   ]len1
              blt   :1
@@ -3438,13 +3438,13 @@ findlable
              cmp   ]len2
              beq   :movefound
 :goleft      rep   $30
-             ldy   #18
+             ldy   #o_lableft
              lda   [lableptr],y
              bmi   :nf1
              sta   ]pos
              jmp   ]lup
 :goright     rep   $30
-             ldy   #20
+             ldy   #o_labright
              lda   [lableptr],y
              bmi   :nf1
              sta   ]pos
@@ -3535,7 +3535,7 @@ insertlable
              iny
              lda   [lableptr1],y
              sta   lableptr+2
-             ldy   #24
+             ldy   #o_lablocal
              lda   [lableptr],y
              jpl   :start
              lda   globlab
@@ -3553,7 +3553,7 @@ insertlable
              iny
              lda   [lableptr1],y
              sta   lableptr+2
-             ldy   #24
+             ldy   #o_lablocal
              lda   lablect
              sta   [lableptr],y                        ;set local ptr for GLable
              jmp   :save
@@ -3599,7 +3599,7 @@ insertlable
              stz   ]len2+1
              ldx   #$02                                ;start at byte 2
              txy
-]lup1        cpx   #$10
+]lup1        cpx   #lab_size+1
              jeq   :error2
              cpx   ]len1
              blt   :1
@@ -3622,7 +3622,7 @@ insertlable
              lda   ]len1
              cmp   ]len2
              bne   :goleft
-:replace     ldy   #26                                 ;offset to equ value
+:replace     ldy   #o_labtype                                 ;offset to equ value
              lda   labtype
              sta   [lableptr],y
              iny
@@ -3636,7 +3636,7 @@ insertlable
              sta   [lableptr],y
              jmp   :nosave
 :goleft      rep   $30
-             ldy   #18                                 ;leftptr
+             ldy   #o_lableft                          ;leftptr
              lda   [lableptr],y
              bpl   :p1
              lda   lablect
@@ -3645,7 +3645,7 @@ insertlable
 :p1          sta   ]pos
              jmp   ]lup
 :goright     rep   $30
-             ldy   #20                                 ;leftptr
+             ldy   #o_labright                          ;rightptr
              lda   [lableptr],y
              bpl   :p2
              lda   lablect
@@ -3700,11 +3700,11 @@ insertlable
              clc
              adc   #labstr
              tax                                       ;source low word
-             lda   #31                                 ;MVN
+             lda   #sym_size-1                         ;MVN
              phb
 :mvn         mvn   $000000,$000000
              plb
-             ldy   #26
+             ldy   #o_labtype
              lda   [lableptr],y
              bpl   :and
              inc   rellabct
@@ -3744,7 +3744,7 @@ insertlable
              sta   ]len2
              ldy   #$02
              tyx                                       ;start at byte 2
-]lup1        cpx   #$10
+]lup1        cpx   #lab_size+1
              jeq   :error2
              cpx   ]len1
              blt   :fi1
@@ -3768,7 +3768,7 @@ insertlable
              cmp   ]len2
              bne   :figoleft
 :fireplace   rep   $30
-             ldy   #26                                 ;offset to equ value
+             ldy   #o_labtype                                 ;offset to equ value
              lda   labtype
              sta   [lableptr],y
              iny
@@ -3782,10 +3782,10 @@ insertlable
              sta   [lableptr],y
              jmp   :nosave
 :figoright   rep   $30
-             ldy   #20
+             ldy   #o_labright
              jmp   :figo
 :figoleft    rep   $30
-             ldy   #18
+             ldy   #o_lableft
 :figo        lda   lablect
              sta   [lableptr],y
              jmp   :save
@@ -3853,7 +3853,7 @@ drawlables   php
              iny
              lda   [lableptr1],y
              sta   lableptr+2
-             ldy   #18
+             ldy   #o_lableft
              lda   #'R'
              sta   :char
              lda   [lableptr],y
@@ -3865,7 +3865,7 @@ drawlables   php
 :next1       jsr   :print
              lda   #'R'
              sta   :char
-             ldy   #20
+             ldy   #o_labright
              lda   [lableptr],y
              bmi   :done
              pha
@@ -3885,7 +3885,7 @@ drawlables   php
 :print       ldy   #$00
              sty   :offset
              lda   [lableptr],y
-             and   #$0F
+             and   #label_mask
              sta   :len
              sta   :bytes
              bne   :p1
@@ -3938,7 +3938,7 @@ drawlables   php
              cpx   :len
              blt   ]lup
              beq   ]lup
-             lda   #$14
+             lda   #lab_size+5
              sec
              sbc   :bytes
              tax
@@ -3950,7 +3950,7 @@ drawlables   php
              bpl   ]lup
              lda   #'$'
              jsr   drawchar
-             ldy   #28+2
+             ldy   #o_labval+2
              ldx   #$03
 ]lup         lda   [lableptr],y
              and   #$FF
@@ -3968,7 +3968,7 @@ drawlables   php
              jsr   drawchar
              lda   :offset
              clc
-             adc   #26
+             adc   #o_labtype
              tay
              lda   [lableptr],y
              jsr   prbytel
@@ -3976,14 +3976,14 @@ drawlables   php
              jsr   drawchar
              lda   :offset
              clc
-             adc   #16
+             adc   #o_labnum
              tay
              lda   [lableptr],y
              jsr   prbytel
 
              lda   #$0D
              jsr   drawchar
-             ldy   #24                                 ;offset to local labels
+             ldy   #o_lablocal                                 ;offset to local labels
              lda   [lableptr],y
              bmi   :rts
              pha

--- a/src/asm/asm.cond.s
+++ b/src/asm/asm.cond.s
@@ -257,15 +257,15 @@ macop         sep   $30
               plx
               cmp   #' '+1
               blt   :slab
-              cpx   #$0f
+              cpx   #lab_size
               bge   :siny
               sta   labstr+1,x
 :siny         iny
               inx
               jmp   ]l
-:slab         cpx   #$10
+:slab         cpx   #lab_size+1
               blt   :slab1
-              ldx   #$0f
+              ldx   #lab_size
 :slab1        stx   labstr
               lda   #$ff
               sta   linelable
@@ -310,14 +310,14 @@ macop         sep   $30
               pea   #symfull
               jmp   :error
 
-:init         ldy   #26
+:init         ldy   #o_labtype
               lda   #$8004
               sta   [lableptr],y
-              ldy   #28
+              ldy   #o_labval
               lda   nextlableptr
               sta   [lableptr],y
               tax
-              ldy   #30
+              ldy   #o_labval+2
               lda   nextlableptr+2
               sta   [lableptr],y
               sta   lableptr+2
@@ -351,7 +351,7 @@ macop         sep   $30
               sta   [lableptr],y
               ldy   #6
               sta   [lableptr],y
-              ldy   #26
+              ldy   #o_labtype
               sta   [lableptr],y
               jsr   inclablect
               bcs   :err1
@@ -384,7 +384,7 @@ pmcop         php
               dey
               ldx   #$00
 ]lup          lda   [lineptr],y
-              cpx   #15
+              cpx   #lab_size
               bge   :c1
               sta   labstr+1,x
 :c1           cmp   #' '+1
@@ -395,14 +395,14 @@ pmcop         php
               beq   :ok1
               inx
               iny
-              cpx   #$10
+              cpx   #lab_size+1
               blt   ]lup
               bra   :ok
 :ok1          iny
 :ok           txa
-              cmp   #$10
+              cmp   #lab_size+1
               blt   :ls
-              lda   #$0f
+              lda   #lab_size
 :ls           sta   labstr
               sty   :y
               sep   $30
@@ -415,7 +415,7 @@ pmcop         php
 * bcc :builtin ;not found so try built in macs
               bcc   :sec
               rep   $30
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               cmp   #absolutebit.macrobit
               bne   :notmac
@@ -581,7 +581,7 @@ initmac       php
               sta   macstack+6,x
               lda   lastlen
               sta   macstack+8,x
-              ldy   #16
+              ldy   #o_labnum 
               lda   [lableptr],y
               sta   macstack+10,x
 
@@ -590,10 +590,10 @@ initmac       php
               sta   flen
               sta   flen+2
 
-              ldy   #30
+              ldy   #o_labval+2
               lda   [lableptr],y
               sta   workspace+2
-              ldy   #28
+              ldy   #o_labval
               lda   [lableptr],y
               sta   workspace
               ldy   #2
@@ -904,7 +904,7 @@ expandmac     php
               blt   :cpx
               cmp   #'>'+1
               blt   :errbl1                ;"<=>" not allowed either..
-:cpx          cpx   #$0f
+:cpx          cpx   #lab_size
               bge   :gliny
               sta   labstr+1,x
               inx
@@ -917,9 +917,9 @@ expandmac     php
 :fjmp         jmp   :flushiny
 :sjmp         jmp   :savlen
 
-:glabdone     cpx   #$10
+:glabdone     cpx   #lab_size+1
               blt   :gl2
-              ldx   #$0f
+              ldx   #lab_size
 :gl2          stx   labstr
               cmp   #' '
               bge   :getopcode
@@ -1541,10 +1541,10 @@ macinsert
               iny
               lda   [lableptr1],y
               sta   lableptr+2
-              ldy   #28
+              ldy   #o_labval
               lda   [lableptr],y
               sta   ]ptr
-              ldy   #30
+              ldy   #o_labval+2
               lda   [lableptr],y
               sta   ]ptr+2
               ldy   #$04
@@ -1553,7 +1553,7 @@ macinsert
               ldy   #$06
 :py2          lda   []ptr],y
               sta   :count
-              ldy   #24
+              ldy   #o_lablocal
               lda   [lableptr],y
               jpl   :start
               lda   macstack+10,x
@@ -1562,7 +1562,7 @@ macinsert
               jmp   :error
 :ne3          sta   ]pos
               sta   labprev
-              ldy   #24
+              ldy   #o_lablocal
               lda   lablect
               sta   [lableptr],y           ;set local ptr for GLable
 :save         rep   $30
@@ -1593,7 +1593,7 @@ macinsert
               stz   ]len2+1
               ldx   #$02                   ;start at byte 2
               txy
-]lup1         cpx   #$10
+]lup1         cpx   #lab_size+1
               jeq   :error2
               cpx   ]len1
               blt   :1
@@ -1616,7 +1616,7 @@ macinsert
               lda   ]len1
               cmp   ]len2
               bne   :goleft
-:replace      ldy   #22                    ;offset to equ value
+:replace      ldy   #o_labprev                    ;offset to equ value
               lda   [lableptr],y
 :rl           tay
               iny
@@ -1659,7 +1659,7 @@ macinsert
               sta   [macptr],y
               jmp   :nosave
 :goleft       rep   $30
-              ldy   #18                    ;leftptr
+              ldy   #o_lableft             ;leftptr
               lda   [lableptr],y
               bpl   :p1
               lda   lablect
@@ -1668,7 +1668,7 @@ macinsert
 :p1           sta   ]pos
               jmp   ]lup
 :goright      rep   $30
-              ldy   #20                    ;leftptr
+              ldy   #o_labright            ;rightptr
               lda   [lableptr],y
               bpl   :p2
               lda   lablect
@@ -1742,7 +1742,7 @@ macinsert
               clc
               adc   #labstr
               tax                          ;source low word
-              lda   #31                    ;MVN
+              lda   #sym_size-1            ;MVN
               phb
 :mvn          mvn   $000000,$000000
               plb
@@ -1798,14 +1798,14 @@ macfind
               iny
               lda   [lableptr1],y
               sta   lableptr+2
-              ldy   #24
+              ldy   #o_lablocal
               lda   [lableptr],y
               jmi   :nf1
               sta   ]pos
-              ldy   #28
+              ldy   #o_labval
               lda   [lableptr],y
               tax
-              ldy   #30
+              ldy   #o_labval+2
               lda   [lableptr],y
               sta   lableptr+2
               stx   lableptr
@@ -1833,7 +1833,7 @@ macfind
               sep   $20
               ldx   #$02                   ;start at byte 2
               txy
-]lup1         cpx   #$10
+]lup1         cpx   #lab_size+1
               bge   :movefound
               cpx   ]len1
               blt   :1
@@ -1858,13 +1858,13 @@ macfind
               cmp   ]len2
               beq   :movefound
 :goleft       rep   $30
-              ldy   #18
+              ldy   #o_lableft
               lda   [lableptr],y
               bmi   :nf1
               sta   ]pos
               jmp   ]lup
 :goright      rep   $30
-              ldy   #20
+              ldy   #o_labright
               lda   [lableptr],y
               bmi   :nf1
               sta   ]pos
@@ -1883,7 +1883,7 @@ macfind
               iny
               lda   [lableptr1],y
               sta   lableptr+2
-              ldy   #22
+              ldy   #o_labprev
               lda   [lableptr],y
 :lup          tay
               iny
@@ -1903,10 +1903,10 @@ macfind
               iny
               iny
               lda   [macptr],y
-              ldy   #30
+              ldy   #o_labval+2
               sta   [lableptr],y
               txa
-              ldy   #28
+              ldy   #o_labval
               sta   [lableptr],y
               plp
               sec

--- a/src/asm/asm.dsk.s
+++ b/src/asm/asm.dsk.s
@@ -702,7 +702,7 @@ writerel     php                                                     ;must enter
              clc
              adc           #4
              sta           :request
-             ldy           #26
+             ldy           #o_labtype
              lda           [lableptr],y
              bit           #entrybit.externalbit
              jeq           :rts
@@ -720,7 +720,7 @@ writerel     php                                                     ;must enter
              blt           ]lup
 
              rep           $30
-             ldy           #26
+             ldy           #o_labtype
              lda           [lableptr],y
              bit           #entrybit
              bne           :ent1
@@ -741,7 +741,7 @@ writerel     php                                                     ;must enter
              bpl           :value
              lda           #$20
              tsb           :len
-:value       ldy           #28
+:value       ldy           #o_labval
              lda           :len
              and           #%00011111
              tax
@@ -757,7 +757,7 @@ writerel     php                                                     ;must enter
              rep           $20
              and           #$80
              beq           :writeit
-             ldy           #22
+             ldy           #o_labprev
              lda           [lableptr],y
              and           #$00ff
              ora           :buffer+1,x

--- a/src/asm/asm.eval.s
+++ b/src/asm/asm.eval.s
@@ -373,7 +373,7 @@ doflags       php
               iny
               lda   [lableptr1],y
               sta   lableptr+2
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               bit   #externalbit
               beq   :y
@@ -391,7 +391,7 @@ doflags       php
               iny
               lda   [lableptr1],y
               sta   lableptr+2
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               bit   #externalbit
               beq   :test
@@ -1323,16 +1323,16 @@ getnum        php
 * lda evallevel           ;don't need to do this here
 * bne :lxit               ;unless level>256
               lda   #'}'
-:iny          cpx   #$0f
+:iny          cpx   #lab_size
               bge   :iny1
               sta   labstr+1,x
 :iny1         iny
               inx
               jmp   ]lup
 :lxit         txa
-              cmp   #$0f+1
+              cmp   #lab_size+1
               blt   :lx
-              lda   #$0f
+              lda   #lab_size
 :lx           sta   labstr
               sty   :next
               jsr   findlabval
@@ -1348,13 +1348,13 @@ getnum        php
 :errlab       lda   #undeflable
               jmp   :errxit
 :lfound       rep   $30
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               pha
-              ldy   #16
+              ldy   #o_labnum
               lda   [lableptr],y
               pha
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               ora   #$2000                 ;indicate used!
               sta   [lableptr],y
@@ -1374,15 +1374,15 @@ getnum        php
               beq   :labcont
               bit   #dumflag
               bne   :labcont
-              ldy   #16
+              ldy   #o_labnum
               lda   [lableptr],y
               sta   zrel
 
 :labcont      rep   $30
-:lsta1        ldy   #28
+:lsta1        ldy   #o_labval
               lda   [lableptr],y
               sta   val
-              ldy   #30
+              ldy   #o_labval+2
               lda   [lableptr],y
               sta   val+2
               jmp   :lbxit

--- a/src/asm/asm.header.s
+++ b/src/asm/asm.header.s
@@ -12,6 +12,7 @@
             use   ../macros/builtin.macs
             use   ../macros/qatools.macs
             use   ../data/qa.equates
+            use   ../data/sym.equates
 
             use   asm.macs
 

--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -1043,14 +1043,14 @@ equate        php
               bpl       :normal
               jsr       findlable
               bcc       :bl
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               bit       #equatebit
               beq       :normal
-              ldy       #28
+              ldy       #o_labval
               lda       [lableptr],y
               sta       :oldval
-              ldy       #30
+              ldy       #o_labval+2
               lda       [lableptr],y
               sta       :oldval+2
               ldx       #$00
@@ -1071,13 +1071,13 @@ equate        php
               bpl       :ok
               jsr       findlable
               bcc       :bl
-              ldy       #28
+              ldy       #o_labval
               lda       [lableptr],y
               sta       :oldval
-              ldy       #30
+              ldy       #o_labval+2
               lda       [lableptr],y
               sta       :oldval+2
-              ldy       #16
+              ldy       #o_labnum
               sty       :foundflag
               lda       [lableptr],y
               jmp       :ok
@@ -1104,7 +1104,7 @@ equate        php
               and       #%01100000
               beq       :nomac
 
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               bit       #variablebit
               bne       :nomac
@@ -1129,7 +1129,7 @@ equate        php
               tyx
               sta       labstr,x
               iny
-              cpy       #16
+              cpy       #lab_size+1
               blt       ]lup
               plp
               jmp       insertlable
@@ -1146,17 +1146,17 @@ equate        php
               tyx
               sta       labstr,x
               iny
-              cpy       #16
+              cpy       #lab_size+1
               blt       ]lup
               jsr       findlable
               bcs       :macp21
               pea       #undeflable
               jmp       :err
 :macp21       rep       $30
-              ldy       #28
+              ldy       #o_labval
               lda       [lableptr],y
               sta       equateval
-              ldy       #30
+              ldy       #o_labval+2
               lda       [lableptr],y
               sta       equateval+2
               jmp       :noerr
@@ -1168,14 +1168,14 @@ equate        php
               sta       lableptr
               lda       :ptr+2
               sta       lableptr+2
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               bit       #variablebit
               beq       :eval
-              ldy       #28
+              ldy       #o_labval
               lda       varval
               sta       [lableptr],y
-              ldy       #30
+              ldy       #o_labval+2
               lda       varval+2
               sta       [lableptr],y
 :eval         ldx       #$00
@@ -1187,14 +1187,14 @@ equate        php
               sta       lableptr
               lda       :ptr+2
               sta       lableptr+2
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               and       #variablebit
               beq       :equval
-              ldy       #28
+              ldy       #o_labval
               lda       varval
               sta       [lableptr],y
-              ldy       #30
+              ldy       #o_labval+2
               lda       varval+2
               sta       [lableptr],y
               ldx       #$00
@@ -1204,7 +1204,7 @@ equate        php
               sta       lableptr
               lda       :ptr+2
               sta       lableptr+2
-:entry        ldy       #26
+:entry        ldy       #o_labtype
               lda       [lableptr],y
               and       #$7FFF
               ora       #equatebit
@@ -1220,10 +1220,10 @@ equate        php
               iny
               lda       lvalue+2
               sta       [lableptr],y
-:equval       ldy       #28
+:equval       ldy       #o_labval
               lda       [lableptr],y
               sta       equateval
-              ldy       #30
+              ldy       #o_labval+2
               lda       [lableptr],y
               sta       equateval+2
 :noerr        pea       $00
@@ -1235,11 +1235,11 @@ equate        php
               lda       merrcode
               cmp       #duplable
               bne       :epla
-              ldy       #28
+              ldy       #o_labval
               lda       [lableptr],y
               cmp       :oldval
               bne       :epla
-              ldy       #30
+              ldy       #o_labval+2
               lda       [lableptr],y
               cmp       :oldval+2
               bne       :epla
@@ -1333,14 +1333,14 @@ equeval       php
 
               jsr       findlable
               bcc       :readkey
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               bit       #linkerbit
               beq       :duplicate
-              ldy       #28
+              ldy       #o_labval
               lda       [lableptr],y
               sta       lvalue
-              ldy       #30
+              ldy       #o_labval+2
               lda       [lableptr],y
               sta       lvalue+2
               lda       #$00                                                  ;0 here if linker passed value
@@ -1397,7 +1397,7 @@ extop
               iny
               lda       [lableptr1],y
               sta       lableptr+2
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               and       #%11111
               bne       :bad
@@ -1409,7 +1409,7 @@ extop
               sec
               rts
 :equ          stz       :offset
-              ldy       #26                                                   ;point to type
+              ldy       #o_labtype                                                   ;point to type
               lda       [lableptr],y
               bit       #%1100_0000_0011_1111
               bne       :bad
@@ -1417,7 +1417,7 @@ extop
               ora       #externalbit
               sta       [lableptr],y
               phy
-              ldy       #22
+              ldy       #o_labprev
               lda       extcount
               sta       [lableptr],y
               inc       extcount
@@ -1458,16 +1458,16 @@ extop
               beq       :insert
               cmp       #';'
               beq       :insert
-              cpx       #15
+              cpx       #lab_size
               bge       :iny
               sta       labstr+1,x
 :iny          iny
               inx
               jmp       ]lup
 :insert       txa
-              cmp       #$10
+              cmp       #lab_size+1
               blt       :ls
-              lda       #$0f
+              lda       #lab_size
 :ls           sta       labstr
               rep       $30
               sty       :ypos
@@ -1480,7 +1480,7 @@ extop
               dec       fllast
               jcs       :gerr1
               stz       :offset
-              ldy       #26                                                   ;point to type
+              ldy       #o_labtype                                                   ;point to type
               lda       [lableptr],y
               bit       #%1100_0000_0011_1111
               bne       :gerr
@@ -1488,7 +1488,7 @@ extop
               ora       #externalbit
               sta       [lableptr],y
               phy
-              ldy       #22
+              ldy       #o_labprev
               lda       extcount
               sta       [lableptr],y
               inc       extcount
@@ -1546,7 +1546,7 @@ exdop
               iny
               lda       [lableptr1],y
               sta       lableptr+2
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               and       #%11111
               bne       :bad
@@ -1558,7 +1558,7 @@ exdop
               sec
               rts
 :equ          stz       :offset
-              ldy       #26                                                   ;point to type
+              ldy       #o_labtype                                                   ;point to type
               lda       [lableptr],y
               bit       #%1100_0000_0011_1111
               bne       :bad
@@ -1566,7 +1566,7 @@ exdop
               ora       #externalbit
               sta       [lableptr],y
               phy
-              ldy       #22
+              ldy       #o_labprev
               lda       extcount
               sta       [lableptr],y
               inc       extcount
@@ -1607,16 +1607,16 @@ exdop
               beq       :insert
               cmp       #';'
               beq       :insert
-              cpx       #15
+              cpx       #lab_size
               bge       :iny
               sta       labstr+1,x
 :iny          iny
               inx
               jmp       ]lup
 :insert       txa
-              cmp       #$10
+              cmp       #lab_size+1
               blt       :ls
-              lda       #$0f
+              lda       #lab_size
 :ls           sta       labstr
               rep       $30
               sty       :ypos
@@ -1629,7 +1629,7 @@ exdop
               dec       fllast
               jcs       :gerr1
               stz       :offset
-              ldy       #26                                                   ;point to type
+              ldy       #o_labtype                                                   ;point to type
               lda       [lableptr],y
               bit       #%1100_0000_0011_1111
               bne       :gerr
@@ -1637,7 +1637,7 @@ exdop
               ora       #externalbit
               sta       [lableptr],y
               phy
-              ldy       #22
+              ldy       #o_labprev
               lda       extcount
               sta       [lableptr],y
               inc       extcount
@@ -1694,7 +1694,7 @@ entop
               iny
               lda       [lableptr1],y
               sta       lableptr+2
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               and       #macvarbit.externalbit.macrobit.variablebit.localbit
               bne       :bad
@@ -1706,13 +1706,13 @@ entop
               sec
               rts
 :equ          stz       :offset
-              ldy       #26                                                   ;point to type
+              ldy       #o_labtype                                                   ;point to type
               lda       [lableptr],y
               and       #usedbit.absolutebit.equatebit
               ora       #entrybit
               sta       [lableptr],y
               phy
-              ldy       #22
+              ldy       #o_labprev
               lda       entcount
               sta       [lableptr],y
               inc       entcount
@@ -1794,16 +1794,16 @@ entop
               beq       :insert
               cmp       #';'
               beq       :insert
-              cpx       #15
+              cpx       #lab_size
               bge       :iny
               sta       labstr+1,x
 :iny          iny
               inx
               jmp       ]lup
 :insert       txa
-              cmp       #$10
+              cmp       #lab_size+1
               blt       :ls
-              lda       #$0f
+              lda       #lab_size
 :ls           sta       labstr
               rep       $30
               sty       :ypos
@@ -1813,7 +1813,7 @@ entop
               bcc       :gerr3
 
               stz       :offset
-              ldy       #26                                                   ;point to type
+              ldy       #o_labtype                                                   ;point to type
               lda       [lableptr],y
               and       #macvarbit.externalbit.macrobit.variablebit.localbit
               bne       :gerr
@@ -1821,7 +1821,7 @@ entop
               and       #usedbit.absolutebit.equatebit
               ora       #entrybit                                             ;entry lable
               sta       [lableptr],y
-              ldy       #22
+              ldy       #o_labprev
               lda       entcount
               sta       [lableptr],y
               inc       entcount
@@ -2535,11 +2535,11 @@ ddbop         ldx       #$00
               lda       [lableptr1],y
               sta       lableptr+2
               stz       :offset
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               bit       #externalbit
               beq       :internal
-              ldy       #22
+              ldy       #o_labprev
               lda       [lableptr],y
               and       #$00ff
               sta       noshift+1
@@ -4529,7 +4529,7 @@ varop         lda       macflag
               dec       fllast
               bcc       :eval
               rts
-:eval         ldy       #16
+:eval         ldy       #o_labnum
               lda       [lableptr],y
               sta       :label
               lda       #$ffff
@@ -4549,7 +4549,7 @@ varop         lda       macflag
               iny
               lda       [lableptr1],y
               sta       lableptr+2
-              ldy       #26
+              ldy       #o_labtype
               lda       [lableptr],y
               and       #$7FFF
               bit       lableused

--- a/src/asm/asm.vars.s
+++ b/src/asm/asm.vars.s
@@ -79,7 +79,7 @@ absolutebit     =     %1000_0000_0000_0000
 *** Assembly Zpage Equates ***
                 dum   $00
 
-labstr          ds    16                    ;Lable STR that we are working on
+labstr          ds    lab_size+1                    ;Lable STR that we are working on
 labnum          ds    2                     ;REC num of current lable
 lableft         ds    2                     ;B-Tree Structures
 labright        ds    2
@@ -93,7 +93,7 @@ lineptr         ds    4
 printptr        ds    4
 linelable       ds    2
 linehaslab      ds    2
-linelabtxt      ds    16,0
+*linelabtxt      ds    lab_size+1,0
 linenum         ds    2
 totallines      ds    2
 
@@ -323,6 +323,8 @@ dskpath         ds    129,0
 atable          ds    128*2,0
 
 titlestr        ds    256,0
+
+linelabtxt      ds    lab_size+1,0
 
 converttable
                 hex   00000000000000000000000000000000

--- a/src/data/sym.equates.S
+++ b/src/data/sym.equates.S
@@ -1,0 +1,16 @@
+              dum 0
+lab_size      equ   31
+label_mask    equ   31
+
+o_labstr      ds    lab_size+1 ; 0
+o_labnum      ds    2   ; 16
+o_lableft     ds    2   ; 18
+o_labright    ds    2   ; 20
+o_labprev     ds    2   ; 22
+o_lablocal    ds    2   ; 24
+o_labtype     ds    2   ; 26
+o_labval      ds    4   ; 28
+
+sym_size      equ   *
+              dend
+

--- a/src/data/sym.equates.S
+++ b/src/data/sym.equates.S
@@ -3,14 +3,13 @@ lab_size      equ   31
 label_mask    equ   31
 
 o_labstr      ds    lab_size+1 ; 0
-o_labnum      ds    2   ; 16
-o_lableft     ds    2   ; 18
-o_labright    ds    2   ; 20
-o_labprev     ds    2   ; 22
-o_lablocal    ds    2   ; 24
-o_labtype     ds    2   ; 26
-o_labval      ds    4   ; 28
+o_labnum      ds    2   ; 32
+o_lableft     ds    2   ; 34
+o_labright    ds    2   ; 36
+o_labprev     ds    2   ; 38
+o_lablocal    ds    2   ; 40
+o_labtype     ds    2   ; 42
+o_labval      ds    4   ; 44
 
 sym_size      equ   *
               dend
-

--- a/src/link/link.eval.s
+++ b/src/link/link.eval.s
@@ -367,7 +367,7 @@ doflags       php
               iny
               lda   [lableptr1],y
               sta   lableptr+2
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               bit   #externalbit
               beq   :y
@@ -385,7 +385,7 @@ doflags       php
               iny
               lda   [lableptr1],y
               sta   lableptr+2
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               bit   #externalbit
               beq   :test
@@ -1244,16 +1244,16 @@ getnum        php
 * lda evallevel           ;don't need to do this here
 * bne :lxit               ;unless level>256
               lda   #'}'
-:iny          cpx   #$0f
+:iny          cpx   #lab_size
               bge   :iny1
               sta   labstr+1,x
 :iny1         iny
               inx
               jmp   ]lup
 :lxit         txa
-              cmp   #$0f+1
+              cmp   #lab_size+1
               blt   :lx
-              lda   #$0f
+              lda   #lab_size
 :lx           sta   labstr
               sty   :next
               jsr   findlable
@@ -1269,12 +1269,12 @@ getnum        php
 :errlab       lda   #undeflable
               jmp   :errxit
 :lfound       rep   $30
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               pha
-              ldy   #16
+              ldy   #o_labnum
               lda   [lableptr],y
-              ldy   #26
+              ldy   #o_labtype
               lda   [lableptr],y
               ora   #linkusedbit           ;indicate used!
               sta   [lableptr],y
@@ -1294,16 +1294,16 @@ getnum        php
               beq   :labcont
               bit   #dumflag
               bne   :labcont
-              ldy   #16
+              ldy   #o_labnum
               lda   [lableptr],y
               sta   zrel
               fin
 
 :labcont      rep   $30
-:lsta1        ldy   #28
+:lsta1        ldy   #o_labval
               lda   [lableptr],y
               sta   val
-              ldy   #30
+              ldy   #o_labval+2
               lda   [lableptr],y
               sta   val+2
 :lbxit        ldy   :next

--- a/src/link/link.header.s
+++ b/src/link/link.header.s
@@ -14,6 +14,7 @@ doexpress    =     $01
              use   ../macros/builtin.macs
              use   ../macros/qatools.macs
              use   ../data/qa.equates
+             use   ../data/sym.equates
 
              use   link.macs
 

--- a/src/link/link.vars.s
+++ b/src/link/link.vars.s
@@ -106,7 +106,7 @@ srelocsize        ds    4
 **** DP storage ****
                   dum   $00
 zpage             ds    4
-labstr            ds    16                    ;Lable STR that we are working on
+labstr            ds    lab_size+1            ;Lable STR that we are working on
 labnum            ds    2                     ;REC num of current lable
 lableft           ds    2                     ;B-Tree Structures
 labright          ds    2
@@ -114,7 +114,7 @@ labprev           ds    2
 lablocal          ds    2                     ;REC of Local Lable Tree
 labtype           ds    2                     ;Type of Label
 labval            ds    4                     ;EQU value of Lable
-foundlable        ds    32                    ;lable REC returned from FINDLABLE
+*foundlable        ds    sym_size              ;lable REC returned from FINDLABLE
 globlab           ds    2                     ;REC of Current Global Lable
 myvalue           ds    4
 lvalue            ds    4
@@ -178,6 +178,7 @@ here              =     *
                   err   */$100
                   dend
 
+foundlable        ds    sym_size              ;lable REC returned from FINDLABLE
 
 asmpath           ds    130,0
 rezpath           ds    130,0

--- a/src/link/linker.1.s
+++ b/src/link/linker.1.s
@@ -415,15 +415,15 @@ linkline        php
                 cmp       #' '
                 blt       :done
                 beq       :lable
-                cpx       #15
+                cpx       #lab_size
                 bge       :nosta
                 sta       newlable+1,x
 :nosta          inx
                 jmp       ]lup
 :lable          txa
-                cmp       #15
+                cmp       #lab_size
                 blt       :l1
-                lda       #15
+                lda       #lab_size
 :l1             sta       newlable
                 jmp       :op
 
@@ -1008,9 +1008,9 @@ equop           bit       passnum
                 lda       newlable
                 and       #$ff
                 beq       :badlable
-                cmp       #15
+                cmp       #lab_size
                 blt       :tx1
-                lda       #15
+                lda       #lab_size
 :tx1            tax
                 sep       $20
                 sta       labstr
@@ -1048,9 +1048,9 @@ equ1op          bit       passnum
                 lda       newlable
                 and       #$ff
                 beq       :badlable
-                cmp       #15
+                cmp       #lab_size
                 blt       :tx1
-                lda       #15
+                lda       #lab_size
 :tx1
                 tax
                 sep       $20
@@ -1116,9 +1116,9 @@ extop           bit       passnum
                 lda       newlable
                 and       #$ff
                 beq       :badlable
-                cmp       #15
+                cmp       #lab_size
                 blt       :tx1
-                lda       #15
+                lda       #lab_size
 :tx1
                 tax
                 sep       $20
@@ -1158,9 +1158,9 @@ geqop           bit       passnum
                 lda       newlable
                 and       #$ff
                 beq       :badlable
-                cmp       #15
+                cmp       #lab_size
                 blt       :tx1
-                lda       #15
+                lda       #lab_size
 :tx1
                 tax
                 sep       $20
@@ -1199,9 +1199,9 @@ kbdop           bit       passnum
                 lda       newlable
                 and       #$ff
                 beq       :badlable
-                cmp       #15
+                cmp       #lab_size
                 blt       :tx1
-                lda       #15
+                lda       #lab_size
 :tx1
                 tax
                 sep       $20
@@ -1541,7 +1541,7 @@ impop           sec
                 and       #$7f
                 cmp       #':'
                 beq       :set
-                cpx       #16
+                cpx       #lab_size+1
                 bge       :inx
                 cmp       #'.'
                 bne       :sta
@@ -1553,9 +1553,9 @@ impop           sec
                 blt       :loop2
                 beq       :loop2
 :set            txa
-                cmp       #15
+                cmp       #lab_size
                 blt       :set1
-                lda       #15
+                lda       #lab_size
 :set1           sta       labstr
                 rep       $30
                 lda       reloffset
@@ -1565,7 +1565,7 @@ impop           sec
                 lda       #linkentrybit
                 jsr       insertlable
                 bcs       :sec
-                ldy       #24
+                ldy       #o_lablocal
                 lda       segnum
                 sta       [lableptr],y
                 plp
@@ -2062,9 +2062,9 @@ buildentries
 :abs            ply
                 lda       1,s
                 and       #%00011111
-                cmp       #15
+                cmp       #lab_size
                 blt       :tx1
-                lda       #15
+                lda       #lab_size
 :tx1
                 tay
                 tax
@@ -2089,7 +2089,7 @@ buildentries
                 plp
                 sec
                 rts
-:ok2            ldy       #24
+:ok2            ldy       #o_lablocal
                 lda       segnum
                 sta       [lableptr],y
 :next           pla
@@ -2457,10 +2457,10 @@ relocatefinal
                 sec
                 sbc       #$8000
                 clc
-                adc       foundlable+28
+                adc       foundlable+o_labval
                 sta       [tempptr],y
                 sta       omfoff2
-                lda       foundlable+26
+                lda       foundlable+o_labtype
                 and       #$0020
                 jne       :clc
                 lda       #$02
@@ -2540,12 +2540,12 @@ relocatefinal
                 sec
                 sbc       #$8000
                 clc
-                adc       foundlable+28
+                adc       foundlable+o_labval
                 sta       omfoff2
                 xba
                 sta       [tempptr],y
 
-                lda       foundlable+26
+                lda       foundlable+o_labtype
                 and       #$0020
                 jne       :clc
 
@@ -2675,18 +2675,18 @@ relocatefinal
                 dey
                 lda       :lowbyte
                 clc
-                adc       foundlable+28
+                adc       foundlable+o_labval
                 sta       omfoff2
                 sty       :omfy
                 sta       [tempptr],y
                 iny
                 iny
                 lda       :lowbyte+2
-                adc       foundlable+30
+                adc       foundlable+o_labval+2
                 sep       $20
                 sta       [tempptr],y
                 rep       $20
-                lda       foundlable+26
+                lda       foundlable+o_labtype
                 and       #$0020                    ;absolute lable?
                 jne       :clc
 
@@ -2782,12 +2782,12 @@ relocatefinal
                 lda       [tempptr],y
                 and       #$ff
                 clc
-                adc       foundlable+28
+                adc       foundlable+o_labval
                 sta       omfoff2
                 sep       $20
                 sta       [tempptr],y
                 rep       $20
-                lda       foundlable+26
+                lda       foundlable+o_labtype
                 and       #$0020
                 jne       :clc
 
@@ -2876,13 +2876,13 @@ relocatefinal
                 sec
                 sbc       #$8000
                 clc
-                adc       foundlable+28
+                adc       foundlable+o_labval
                 sta       omfoff2
                 xba
                 sep       $20
                 sta       [tempptr],y
                 rep       $20
-                lda       foundlable+26
+                lda       foundlable+o_labtype
                 and       #$0020
                 jne       :clc
 
@@ -3035,16 +3035,16 @@ relocatefinal
                 clc
                 adc       reloffset
                 sta       omfoff1
-                lda       foundlable+28
+                lda       foundlable+o_labval
                 clc
                 adc       :lowbyte
                 sta       omfoff2
-                lda       foundlable+30
+                lda       foundlable+o_labval+2
                 adc       :lowbyte+2
                 sep       $20
                 sta       [tempptr],y
                 rep       $20
-                lda       foundlable+26
+                lda       foundlable+o_labtype
                 and       #$0020
                 jne       :clc
 
@@ -3083,18 +3083,18 @@ relocatefinal
                 clc
                 adc       reloffset
                 sta       omfoff1
-                lda       foundlable+28
+                lda       foundlable+o_labval
                 clc
                 adc       :lowbyte
                 sta       :lowbyte
                 sta       omfoff2
-                lda       foundlable+30
+                lda       foundlable+o_labval+2
                 adc       :lowbyte+2
                 sta       :lowbyte+2
                 lda       :lowbyte+1
                 sta       [tempptr],y
 
-                lda       foundlable+26
+                lda       foundlable+o_labtype
                 and       #$0020
                 jne       :clc
 
@@ -3160,7 +3160,7 @@ getexternal     php
                 jmp       ]lup
 :notfound       rep       $20
                 lda       labstr
-                and       #$0f
+                and       #label_mask
                 tay
                 ldx       #$01
 ]lup            sep       $20
@@ -3207,9 +3207,9 @@ getexternal     php
                 ldy       :offset
                 lda       [tempptr2],y
                 and       #%00011111
-                cmp       #15
+                cmp       #lab_size
                 blt       :tx1
-                lda       #15
+                lda       #lab_size
 :tx1
                 sta       :offset
                 ldx       #$00
@@ -3234,14 +3234,14 @@ getexternal     php
                 sec
                 ror       :cased
                 jmp       :find
-:itsfound       ldy       #26
+:itsfound       ldy       #o_labtype
                 lda       [lableptr],y
                 ora       #linkentused
                 sta       [lableptr],y
-:itsfound2      lda       foundlable+26
+:itsfound2      lda       foundlable+o_labtype
                 bit       #linkentrybit
                 jeq       :notfound
-                lda       foundlable+24             ;get lable's seg number
+                lda       foundlable+o_lablocal             ;get lable's seg number
                 sta       extseg
                 cmp       segnum
                 beq       :bit
@@ -3252,7 +3252,7 @@ getexternal     php
                 rep       $20
 :bit            bit       :zpage
                 bpl       :clc
-                lda       foundlable+29
+                lda       foundlable+o_labval+1
                 beq       :clc
                 lda       #extnotzp
                 plp

--- a/src/link/linker.2.s
+++ b/src/link/linker.2.s
@@ -322,7 +322,7 @@ jumpentry       php
                 lda         [segmentptr],y
                 sta         segmentptr+2
                 stx         segmentptr
-                lda         foundlable+24
+                lda         foundlable+o_lablocal
                 asl
                 asl
                 asl
@@ -821,13 +821,13 @@ findlable
                 stz         ]offset
                 ldy         #$00
                 lda         [lableptr],y
-                and         #$0F
+                and         #label_mask
                 sta         ]len2
                 sep         $20
                 iny
                 iny
                 ldx         #$02                      ;start at byte 2
-]lup1           cpx         #$10
+]lup1           cpx         #lab_size+1
                 bge         :movefound
                 cpx         ]len1
                 blt         :1
@@ -852,13 +852,13 @@ findlable
                 cmp         ]len2
                 beq         :movefound
 :goleft         rep         $30
-                ldy         #18                       ;leftptr
+                ldy         #o_lableft                ;leftptr
                 lda         [lableptr],y
                 bmi         :notfound
                 sta         ]pos
                 jmp         ]lup
 :goright        rep         $30
-                ldy         #20                       ;leftptr
+                ldy         #o_labright               ;rightptr
                 lda         [lableptr],y
                 bmi         :notfound
                 sta         ]pos
@@ -875,7 +875,7 @@ findlable
                 iny
                 lda         [lableptr1],y
                 sta         lableptr+2
-                ldy         #26
+                ldy         #o_labtype
                 lda         [lableptr],y
                 bit         #linkequbit
                 beq         :ldy
@@ -890,7 +890,7 @@ findlable
                 inx
                 iny
                 iny
-                cpx         #32
+                cpx         #sym_size
                 blt         ]lup
 :mfplp          plp
                 sec
@@ -955,7 +955,7 @@ insertlable
                 iny
                 iny
                 ldx         #$02                      ;start at byte 2
-]lup1           cpx         #$10
+]lup1           cpx         #lab_size+1
                 jeq         :error
                 cpx         ]len1
                 blt         :1
@@ -978,7 +978,7 @@ insertlable
                 lda         ]len1
                 cmp         ]len2
                 bne         :goleft
-:replace        ldy         #26                       #26
+:replace        ldy         #o_labtype
                 lda         [lableptr],y
                 bit         #linkequbit
                 beq         :duperr
@@ -990,7 +990,7 @@ insertlable
 ]mov            lda         labstr,x
                 sta         errlable,x
                 inx
-                cpx         #16
+                cpx         #lab_size+1
                 blt         ]mov
                 rep         $30
                 lda         labtype
@@ -1020,11 +1020,11 @@ insertlable
                 sta         foundlable,x
                 iny
                 iny
-                cpy         #32
+                cpy         #sym_size
                 blt         ]test
                 jmp         :nosave
 :goleft         rep         $30
-                ldy         #18                       ;leftptr
+                ldy         #o_lableft                ;leftptr
                 lda         [lableptr],y
                 bpl         :p1
                 lda         lablect
@@ -1033,7 +1033,7 @@ insertlable
 :p1             sta         ]pos
                 jmp         ]lup
 :goright        rep         $30
-                ldy         #20                       ;leftptr
+                ldy         #o_labright               ;rightptr
                 lda         [lableptr],y
                 bpl         :p2
                 lda         lablect
@@ -1075,7 +1075,7 @@ insertlable
                 sta         foundlable,x
                 inx
                 inx
-                cpx         #32
+                cpx         #sym_size
                 blt         ]test
                 jsr         inclablect
                 rts
@@ -1083,7 +1083,7 @@ insertlable
 drawlabstr      php
                 rep         $30
                 lda         labstr
-                and         #$0f
+                and         #label_mask
                 beq         :cr
                 tay
                 ldx         #$01
@@ -1175,7 +1175,7 @@ insertlableasm
                 iny
                 iny
                 ldx         #$02                      ;start at byte 2
-]lup1           cpx         #$10
+]lup1           cpx         #lab_size+1
                 jeq         :error
                 cpx         ]len1
                 blt         :1
@@ -1198,7 +1198,7 @@ insertlableasm
                 lda         ]len1
                 cmp         ]len2
                 bne         :goleft
-:replace        ldy         #26                       ;offset to equ type
+:replace        ldy         #o_labtype                       ;offset to equ type
                 lda         labtype
                 ora         #$8008
                 sta         [lasmptr],y
@@ -1218,11 +1218,11 @@ insertlableasm
                 inx
                 iny
                 iny
-                cpx         #32
+                cpx         #sym_size
                 blt         ]test
                 jmp         :nosave
 :goleft         rep         $30
-                ldy         #18                       ;leftptr
+                ldy         #o_lableft                ;leftptr
                 lda         [lasmptr],y
                 bpl         :p1
                 lda         asmlablect
@@ -1231,7 +1231,7 @@ insertlableasm
 :p1             sta         ]pos
                 jmp         ]lup
 :goright        rep         $30
-                ldy         #20                       ;leftptr
+                ldy         #o_labright               ;rightptr
                 lda         [lasmptr],y
                 bpl         :p2
                 lda         asmlablect
@@ -1275,7 +1275,7 @@ insertlableasm
                 inx
                 iny
                 iny
-                cpx         #32
+                cpx         #sym_size
                 blt         ]test
                 jsr         incasmlablect
                 rts
@@ -1336,7 +1336,7 @@ traverse        php
                 iny
                 lda         [lableptr1],y
                 sta         lableptr+2
-                ldy         #18
+                ldy         #o_lableft
                 lda         #'R'
                 sta         :char
                 lda         [lableptr],y
@@ -1348,7 +1348,7 @@ traverse        php
 :next2          jsr         :print
                 lda         #'R'
                 sta         :char
-                ldy         #20
+                ldy         #o_labright
                 lda         [lableptr],y
                 bmi         :done
                 pha
@@ -1369,7 +1369,7 @@ traverse        php
                 sta         labstr,x
                 inx
                 inx
-                cpx         #32
+                cpx         #sym_size
                 blt         ]lup
 :jsr            jsr         $ffff
                 sep         $20
@@ -1481,7 +1481,7 @@ move2asm        lda         linksymhdl
                 sta         labtype
                 jsr         insertlableasm
 clrlocals
-                ldy         #26
+                ldy         #o_labtype
                 lda         [lableptr],y
                 and         #linkequvalid!$FFFF
                 sta         [lableptr],y
@@ -1596,7 +1596,7 @@ inclablect      php
                 and         #%11111111
                 bne         :normal
                 psl         #$00
-                psl         #$2000
+                psl         #sym_size*256             ; $2000
                 ldal        userid
                 ora         #linkmemid
                 pha
@@ -1625,7 +1625,7 @@ inclablect      php
                 rts
 :normal         lda         nextlableptr
                 clc
-                adc         #32
+                adc         #sym_size
                 sta         nextlableptr
                 bcc         :rts
                 inc         nextlableptr+2
@@ -1644,7 +1644,7 @@ incasmlablect   php
                 and         #%11111111
                 bne         :normal
                 psl         #$00
-                psl         #$2000
+                psl         #sym_size*256             ; #$2000
                 lda         userid
                 ora         #linkmemid+$100
                 pha
@@ -1673,7 +1673,7 @@ incasmlablect   php
                 rts
 :normal         lda         asmnextlable
                 clc
-                adc         #32
+                adc         #sym_size
                 sta         asmnextlable
                 bcc         :rts
                 inc         asmnextlable+2


### PR DESCRIPTION
Magic number offsets are also replaced with named constants.

Merlin 16+ increased the label size from 12 to 26 at some point and the 15-char limit causes duplicate label errors on some Merlin source code.