### PR TITLE
QAsm Shell fixes

### DIFF
--- a/src/shell/qasm.s
+++ b/src/shell/qasm.s
@@ -154,6 +154,7 @@ QuickASM ENT
  _InitCursor ;no longer waiting to startup
 
  ~CheckClick #TextName ;do we have a doc to open?
+ bcs :9
  txa
  beq :9 ; no- don't open anything
 

--- a/src/shell/qasm2.s
+++ b/src/shell/qasm2.s
@@ -772,22 +772,28 @@ SetCmdHdl
  rts
 
 *------------------------------------------------------
+* _QAGetWord error 
+* $0000 -> no error
+* $00xx -> no word, a = terminating character (anything less than $20, excluding \t )
+* $80xx -> qa tool error
+*  return value will always be 0,0 if there was an error. can never be 0,0 on success.
+*
 :getword
  REP #$20 ;force 16 bit
 ]loop
  ~QAGetWord Ptr;endword;temp ;get a word
  plx
  ply
- beq :0 ;don't modify if no word!
- stx endword
- sty begword
  bcc :1
- tax ;real error, or just no word?
- bmi :1
+ tax ; real error or no word?
+ bpl :0
+ rts ; carry still set
 :0
  inc endword ;no word- look for one!
  bra ]loop
 :1
+ stx endword
+ sty begword
  SEP #$20
  bra :gc ;get first char, uppercase!
 


### PR DESCRIPTION
Fixes a couple problems I encountered when starting up the GUI shell

1. don't run message center code when message center returned an error
2. there was an infinite loop parsing the command table file but I don't recall the exact details.