### PR TITLE
qasm iigs: fix to macro operand parsing for quoted strings

### DIFF
--- a/src/asm/asm.cond.s
+++ b/src/asm/asm.cond.s
@@ -667,66 +667,55 @@ getvars
 
 :flush        lda   (lineptr),y
               cmp   #' '
-              jlt   :move
-              beq   :finy
-              cmp   #';'
-              bne   :first
-              jmp   :move
-:finy         iny
-              jmp   :flush
-:first        cmp   #$22
-              beq   :literal
-              cmp   #$27
-              bne   :giny
-:literal      sta   ]lit
-:giny         sta   macvars,x
-* jsr :print
-              dec   ]ct
-              inx
+              bne   :f0
               iny
-:loop         lda   (lineptr),y
-              cmp   #' '
+              bra   :flush
+:f0
+              jlt   :move
+              cmp   #';'
+              jeq   :move
+
+:first        cmp   #$22
+              beq   :q
+              cmp   #$27
+              beq   :q
+
+:loop
+              sta   macvars,x
+              dec   ]ct
+              beq   :badvar
+              iny
+              inx
+
+              lda   (lineptr),y
+              cmp   #' '+1
               blt   :done
-              beq   :checklit
               cmp   #';'
               beq   :semi
-              cmp   ]lit
-              beq   :littog
-              cmp   #$27
-              beq   :lit1
               cmp   #$22
-              bne   :x1
-:lit1         sta   ]lit
-:x1           xba
-:sta1         lda   ]ct
-              beq   :badvar
-              xba
+              beq   :q
+              cmp   #$27
+              beq   :q
+              bra   :loop
+
+:q            sta   ]lit
+:qloop
               sta   macvars,x
-* jsr :print
+              dec   ]ct
+              beq   :badvar
               iny
               inx
-              dec   ]ct
-              jmp   :loop
-:checklit     xba
-              lda   ]lit
-              bne   :sta1
-              jmp   :done
-:littog       xba
-              lda   ]lit
-              bne   :loff
-              xba
-              sta   ]lit
-              xba
-              jmp   :sta1
-:loff         stz   ]lit
-              jmp   :sta1
+
+              lda   (lineptr),y
+              cmp   #' '
+              blt   :done
+              cmp   ]lit
+              beq   :loop
+              bra   :qloop
+
 :done         sec
               ror   ]done
-:semi         xba
-              lda   ]lit
-              bne   :sta1
-:next         stz   macvars,x
-* jsr :printcr
+:semi         stz   macvars,x
               inx
               iny
               dec   ]ct


### PR DESCRIPTION
macro operand parsing code was a little too clever and had problems if both ' and " delimiters were present.

new code uses separate loops for handing delimited strings and raw strings, to keep things simpler and more correct.

```
xx	mac
	asc ]1
	eom

	xx '"hello"'
	xx "'hello'"
	xx 'hello'
	xx "hello"
	xx 'abc',00
	xx ff

 ```
before:
```
Assembling macstr.s

Bad operand in line: 5.

Bad operand in line: 6.
                     1 xx           mac
                     2              asc  ]1
                     3              eom
                     4
008000:              5              xx   '"hello"'
008000: 22 68 65 6C  5              asc  '"hello"'

008004: 6C 6F 22
                     5              eom
008007:              6              xx   "'hello'"
008007: A7 E8 E5 EC  6              asc  "'hello'"

00800B: EC EF A7
                     6              eom
00800E:              7              xx   'hello'
00800E: 68 65 6C 6C  7              asc  'hello'
008012: 6F
                     7              eom
008013:              8              xx   "hello"
008013: E8 E5 EC EC  8              asc  "hello"
008017: EF
                     8              eom
008018:              9              xx   'abc',00
008018: 61 62 63 00  9              asc  'abc',00
                     9              eom
00801C:              10             xx   ff
00801C: FF           10             asc  ff
                     10             eom

End of QuickASM assembly. 29 bytes, 2 errors, 22 lines, 1 symbols.

Elapsed time = < 1 second.
```

after:
```
Assembling macstr.s

                     1 xx           mac
                     2              asc  ]1
                     3              eom
                     4
008000:              5              xx   '"hello"'
008000: 22 68 65 6C  5              asc  '"hello"'
008004: 6C 6F 22
                     5              eom
008007:              6              xx   "'hello'"
008007: A7 E8 E5 EC  6              asc  "'hello'"
00800B: EC EF A7
                     6              eom
00800E:              7              xx   'hello'
00800E: 68 65 6C 6C  7              asc  'hello'
008012: 6F
                     7              eom
008013:              8              xx   "hello"
008013: E8 E5 EC EC  8              asc  "hello"
008017: EF
                     8              eom
008018:              9              xx   'abc',00
008018: 61 62 63 00  9              asc  'abc',00
                     9              eom
00801C:              10             xx   ff
00801C: FF           10             asc  ff
                     10             eom

End of QuickASM assembly. 29 bytes, 0 errors, 22 lines, 1 symbols.

Elapsed time = < 1 second.
```