### PR TITLE
qlink iigs - truncate opcodes to 3 characters

### DIFF
--- a/src/link/linker.1.s
+++ b/src/link/linker.1.s
@@ -496,12 +496,15 @@ getopcode
                 blt       ]lup
                 beq       ]lup
                 dex
-:done           lda       #$2020
+:done           lda       #$2020                    ;truncate to 3 bytes max
                 sta       opcode+$1,Y
+                sta       opcode+4
                 tya
-                and       #$1F
                 sep       $20
-                sta       opcode
+                cmp       #4
+                bcc       :3
+                lda       #3
+:3              sta       opcode
 ]flush          lda       linebuff,x
                 cmp       #' '
                 bne       :tya


### PR DESCRIPTION
The Merlin linker truncates opcodes to 3 characters.

This allows for things like `TYPe` and `LINk`

eg, Marinetti link file:

```
 LINK I.INIT.L
 LINK I.CALLS.L
 SAV TCPIP
```