### PR TITLE
qasm iigs: print the line when an error is encountered on first pass

### DIFF
--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -394,8 +394,8 @@ asm          php
              lda   1,s
              jsr   asmerror
 
-             lda   passnum
-             beq   :perrpla
+*             lda   passnum
+*             beq   :perrpla
 
              lda   listflag
              pha


### PR DESCRIPTION

When an error is encountered, the line only prints on the second pass. Merlin prints the line for errors on both passes. In most cases, pass 1 errors are fatal so there won't be a second pass to print the error.

before:
```
Assembling error.s


Bad opcode in line: 2.

End of QuickASM assembly. 0 bytes, 1 errors, 0 lines, 0 symbols.

Elapsed time = < 1 second.
```
after:
```
Assembling error.s


Bad opcode in line: 2.
                     2              isnt_this_nicer?     


End of QuickASM assembly. 0 bytes, 1 errors, 0 lines, 0 symbols.

Elapsed time = < 1 second.
```
