### PR TITLE
qasm gs - update program counter w/in data operands

### DIFF
--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -1586,8 +1586,10 @@ initline     php
              sta   lableused
              lda   objptr
              sta   lineobjptr
+             sta   pcobjptr
              lda   objptr+2
              sta   lineobjptr+2
+             sta   pcobjptr+2
 
 :xit         plp
              rts

--- a/src/asm/asm.eval.s
+++ b/src/asm/asm.eval.s
@@ -1285,9 +1285,9 @@ getnum        php
 :xc1          jmp   :doxc                  ;y still on stack!
 :pc           iny
               rep   $30
-              lda   lineobjptr
+              lda   pcobjptr
               sta   val
-              lda   lineobjptr+$2
+              lda   pcobjptr+$2
               sta   val+$2
               lda   modeflag
               bit   #relflag

--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -2527,6 +2527,10 @@ ddbop         ldx       #$00
               jsr       putbyte
               lda       passnum
               beq       :jmp
+              lda       objptr
+              sta       pcobjptr
+              lda       objptr+2
+              sta       pcobjptr+2
               lda       modeflag
               bit       #relflag
               beq       :jmp

--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -2424,6 +2424,12 @@ dwop          php
               lda       lvalue+$1
               jsr       putbyte
               jsr       relcorrect
+              rep       $30
+              lda       objptr
+              sta       pcobjptr
+              lda       objptr+2
+              sta       pcobjptr+2
+              sep       $30
               plx
               txy
               lda       (lineptr),y
@@ -2475,6 +2481,12 @@ dfbop         php
               lda       lvalue
               jsr       putbyte
               jsr       relcorrect
+              rep       $30
+              lda       objptr
+              sta       pcobjptr
+              lda       objptr+2
+              sta       pcobjptr+2
+              sep       $30
               plx
               txy
               lda       (lineptr),y
@@ -2626,6 +2638,12 @@ adrop         php
               lda       lvalue+2
               jsr       putbyte
               jsr       relcorrect
+              rep       $30
+              lda       objptr
+              sta       pcobjptr
+              lda       objptr+2
+              sta       pcobjptr+2
+              sep       $30
               plx
               txy
               lda       (lineptr),y
@@ -2684,6 +2702,12 @@ adrlop        php
               lda       lvalue+$3
               jsr       putbyte
               jsr       relcorrect
+              rep       $30
+              lda       objptr
+              sta       pcobjptr
+              lda       objptr+2
+              sta       pcobjptr+2
+              sep       $30
               plx
               txy
               lda       (lineptr),y

--- a/src/asm/asm.vars.s
+++ b/src/asm/asm.vars.s
@@ -187,6 +187,7 @@ lvalue          ds    4
 myvalue         ds    4
 noshift         ds    4
 lineobjptr      ds    4
+pcobjptr        ds    4
 
 xreg            ds    4                     ;variables used by EVAL
 yreg            ds    4


### PR DESCRIPTION
Fixes #51 

Before:
```
Assembling test/star.s

                     1    
                     2              rel               
                     3    
008000: 80 00=8002   4              bra  *+2          
008002: 1E 00 00 1E  5    a         adr  offset-*,offset-* 
008006: 00 00 
008008: 18 00 00 00  6    b         adrl offset-*,offset-* 
00800C: 18 00 00 00 
008010: 10 00 10 00  7    c         da   offset-*,offset-* 
008014: 0C 00 0C 00  8    d         dw   offset-*,offset-* 
008018: 08 08        9    e         db   offset-*,offset-* 
00801A: 00 06 00 06  10   f         ddb  offset-*,offset-* 
00801E: 02 02        11   g         dfb  offset-*,offset-* 
                     12   
                     13   offset                      

End of QuickASM assembly. 32 bytes, 0 errors, 16 lines, 8 symbols.

Elapsed time = < 1 second.
```

After:
```
Assembling test/star.s

                     1 
                     2              rel               
                     3 
008000: 80 00=8002   4              bra  *+2          
008002: 1E 00 00 1B  5 a            adr  offset-*,offset-* 
008006: 00 00 
008008: 18 00 00 00  6 b            adrl offset-*,offset-* 
00800C: 14 00 00 00 
008010: 10 00 0E 00  7 c            da   offset-*,offset-* 
008014: 0C 00 0A 00  8 d            dw   offset-*,offset-* 
008018: 08 07        9 e            db   offset-*,offset-* 
00801A: 00 06 00 04  10 f           ddb  offset-*,offset-* 
00801E: 02 01        11 g           dfb  offset-*,offset-* 
                     12 
                     13 offset                        

End of QuickASM assembly. 32 bytes, 0 errors, 16 lines, 8 symbols.

Elapsed time = < 1 second.
```

Apple's MDS Assembler (Macintosh Development System, actually developed by a third party) also updated the program counter within the data operand, apparently, so it's rare but Merlin isn't the only one to do that.