### PR TITLE
fix absolute external labels

### DIFF
--- a/src/link/linker.1.s
+++ b/src/link/linker.1.s
@@ -2464,7 +2464,7 @@ relocatefinal
                 sta       [tempptr],y
                 sta       omfoff2
                 lda       foundlable+o_labtype
-                and       #$0020
+                and       #linkabsbit
                 jne       :clc
                 lda       #$02
                 sta       omfbytes
@@ -2549,7 +2549,7 @@ relocatefinal
                 sta       [tempptr],y
 
                 lda       foundlable+o_labtype
-                and       #$0020
+                and       #linkabsbit
                 jne       :clc
 
                 bit       interseg
@@ -2690,7 +2690,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #$0020                    ;absolute lable?
+                and       #linkabsbit                    ;absolute lable?
                 jne       :clc
 
                 bit       interseg
@@ -2791,7 +2791,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #$0020
+                and       #linkabsbit
                 jne       :clc
 
                 bit       interseg
@@ -2886,7 +2886,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #$0020
+                and       #linkabsbit
                 jne       :clc
 
                 bit       interseg
@@ -3048,7 +3048,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #$0020
+                and       #linkabsbit
                 jne       :clc
 
                 lda       #$f5
@@ -3103,7 +3103,7 @@ relocatefinal
                 sta       [tempptr],y
 
                 lda       foundlable+o_labtype
-                and       #$0020
+                and       #linkabsbit
                 jne       :clc
 
                 lda       #$f5

--- a/testdata/3009-abs-ent-1.S
+++ b/testdata/3009-abs-ent-1.S
@@ -1,0 +1,12 @@
+
+	rel
+	ent const
+const	equ $123456 ; only 24-bit value saved in rel dictionary.
+
+	db const
+	dw const
+	adr const
+	adrl const
+	ddb const
+
+	sav 3009-abs-ent-1.L

--- a/testdata/3009-abs-ent-2.S
+++ b/testdata/3009-abs-ent-2.S
@@ -1,0 +1,11 @@
+
+	rel
+	ext const
+
+	db const
+	dw const
+	adr const
+	adrl const
+	ddb const
+
+	sav 3009-abs-ent-2.L

--- a/testdata/3009-abs-ent-link.S
+++ b/testdata/3009-abs-ent-link.S
@@ -1,0 +1,9 @@
+* link file
+* generated file should not have any OMF relocation records.
+
+	ovr all
+	asm 3009-abs-ent-1.S
+	asm 3009-abs-ent-2.S
+	lnk 3009-abs-ent-1.L
+	lnk 3009-abs-ent-2.L
+	sav 3009-abs-ent


### PR DESCRIPTION
absolute external labels were not correctly identified as such and thus treated as relocatable.