### PR TITLE
qlinkgs : make GEQU symbols available to the linker

### DIFF
--- a/src/link/linker.1.s
+++ b/src/link/linker.1.s
@@ -2464,7 +2464,7 @@ relocatefinal
                 sta       [tempptr],y
                 sta       omfoff2
                 lda       foundlable+o_labtype
-                and       #linkabsbit
+                and       #linkabsbit.linkgeqbit
                 jne       :clc
                 lda       #$02
                 sta       omfbytes
@@ -2549,7 +2549,7 @@ relocatefinal
                 sta       [tempptr],y
 
                 lda       foundlable+o_labtype
-                and       #linkabsbit
+                and       #linkabsbit.linkgeqbit
                 jne       :clc
 
                 bit       interseg
@@ -2690,7 +2690,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #linkabsbit                    ;absolute lable?
+                and       #linkabsbit.linkgeqbit                    ;absolute lable?
                 jne       :clc
 
                 bit       interseg
@@ -2791,7 +2791,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #linkabsbit
+                and       #linkabsbit.linkgeqbit
                 jne       :clc
 
                 bit       interseg
@@ -2886,7 +2886,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #linkabsbit
+                and       #linkabsbit.linkgeqbit
                 jne       :clc
 
                 bit       interseg
@@ -3048,7 +3048,7 @@ relocatefinal
                 sta       [tempptr],y
                 rep       $20
                 lda       foundlable+o_labtype
-                and       #linkabsbit
+                and       #linkabsbit.linkgeqbit
                 jne       :clc
 
                 lda       #$f5
@@ -3103,7 +3103,7 @@ relocatefinal
                 sta       [tempptr],y
 
                 lda       foundlable+o_labtype
-                and       #linkabsbit
+                and       #linkabsbit.linkgeqbit
                 jne       :clc
 
                 lda       #$f5
@@ -3252,7 +3252,7 @@ getexternal     php
                 ora       #linkentused
                 sta       [lableptr],y
 :itsfound2      lda       foundlable+o_labtype
-                bit       #linkentrybit
+                bit       #linkentrybit.linkgeqbit
                 jeq       :notfound
                 lda       foundlable+o_lablocal             ;get lable's seg number
                 sta       extseg

--- a/testdata/3010-gequ-link.S
+++ b/testdata/3010-gequ-link.S
@@ -1,0 +1,18 @@
+* link file
+* link script gequ symbols are visible to both the assembler and linker
+*
+*
+
+	ovr all
+* this geq available at asm-time
+gequ1	geq 1
+equ1	equ 2
+
+	asm 3010-gequ.S
+* this geq available at link-time
+gequ2	geq 3
+
+	lnk 3010-gequ.L
+	sav 3010-gequ
+
+	ent

--- a/testdata/3010-gequ.S
+++ b/testdata/3010-gequ.S
@@ -1,0 +1,22 @@
+
+	rel
+	xc
+	xc
+
+
+*	ext gequ1
+	ext gequ2
+	lda #gequ1
+	ldy #equ1
+	ldx #gequ2
+	rtl
+
+* verify all sizes work
+	db gequ2
+	dw gequ2
+	ddb gequ2
+	adr gequ2
+	adrl gequ2
+
+	sav 3010-gequ.L
+	sym


### PR DESCRIPTION
In Merlin, link script GEQU (and KBD) values are available to the assembler and the linker, as absolute values.

This makes them available in the link phase (asm phase was already supported).