### PR TITLE
qlinkgs - fix a couple cosmetic issues with error display

### DIFF
--- a/src/link/link.errors.s
+++ b/src/link/link.errors.s
@@ -15,6 +15,7 @@ linkerror   php
             _QASetWindow
 
             _QAIncTotalErrs
+            lda   :errcode
             cmp   #constraint
             jeq   :xit
             cmp   #notresolved
@@ -122,6 +123,7 @@ errtbl      dw    syntax,str1
             dw    badasmcmd,str2
             dw    badcmd,str3
             dw    badlable,str4
+            dw    badlable.$80,str4
             dw    outofmem,str5
             dw    undeflable,str6
             dw    badoperand,str7


### PR DESCRIPTION
1. Some, not all, badlable errors have bit $80 set (fatal indicator I believe). This is missing from the error table so they generate an undefined error.

2. The error code isn't in the accumulator when checking for constraint/not resolved errors (which are handled specially so as to include more detailed information), which would result in a second undefined error displaying for them.