### PR TITLE
qlinkgs: Fix rel DS handling

### DIFF
--- a/src/link/linker.1.s
+++ b/src/link/linker.1.s
@@ -1800,7 +1800,7 @@ lnkop           sec
                 bit       :dsvalid
                 jpl       :xit
                 ldy       :dsy
-                lda       :aux
+                lda       :rel
                 and       #$FF
                 eor       #$FF
                 inc
@@ -1820,6 +1820,15 @@ lnkop           sec
                 psl       :handle
                 _GetHandleSize
                 pll       :size
+
+                sec
+                lda       :size
+                sbc       :aux
+                sta       :rsize
+                lda       :size+2
+                sbc       #0
+                sta       :rsize+2
+
                 lda       :more
                 clc
                 adc       :size
@@ -1867,9 +1876,7 @@ lnkop           sec
                 sta       :dest+2
                 psl       :src
                 psl       :dest
-                pea       $00
-                lda       :more
-                pha
+                psl       :rsize
                 _BlockMove
                 ldy       :aux
                 ldx       #$00
@@ -1912,6 +1919,7 @@ lnkop           sec
 :dest           ds        4
 :byte           ds        2
 :temp           ds        4
+:rsize          ds        4
 
 :constrainterr  php
                 rep       $30

--- a/testdata/3012-rel-ds-1.S
+++ b/testdata/3012-rel-ds-1.S
@@ -1,0 +1,6 @@
+	rel
+
+	nop
+	nop
+
+	sav 3012-rel-ds-1.L

--- a/testdata/3012-rel-ds-2.S
+++ b/testdata/3012-rel-ds-2.S
@@ -1,0 +1,16 @@
+	rel
+
+
+a	ent
+b	ent
+c	ent
+	nop
+	nop
+
+* should generate $100 - 4  bytes of $ff since 2 bytes in first file, 2 bytes above.
+* extra ent labels to verify the DS padding algorithm adjusts the relacation records.
+
+	ds \,$ff
+d	ent
+
+	sav 3012-rel-ds-2.L

--- a/testdata/3012-rel-ds-3.S
+++ b/testdata/3012-rel-ds-3.S
@@ -1,0 +1,9 @@
+	rel
+
+	ext a,b,c,d
+
+	dw a,b,c,d
+
+	ds \,$00
+
+	sav 3012-rel-ds-3.L

--- a/testdata/3012-rel-ds-link.S
+++ b/testdata/3012-rel-ds-link.S
@@ -1,0 +1,15 @@
+*
+* test rel DS \ command to verify it uses the current segment offset,
+* not the current file offset.
+*
+
+	ovr all
+	asm 3012-rel-ds-1.S
+	asm 3012-rel-ds-2.S
+	asm 3012-rel-ds-3.S
+
+	lnk 3012-rel-ds-1.L
+	lnk 3012-rel-ds-2.L
+	lnk 3012-rel-ds-3.L
+
+	sav 3012-rel-ds


### PR DESCRIPTION
Merlin's rel ds fill calculation is based on the total segment size, not the current file size.

Additionally, it was block moving the size of the DS fill rather than the size of the relocation records.