### PR TITLE
qlinkgs - implement the len/pos linker opcodes

### DIFF
--- a/src/link/link.vars.s
+++ b/src/link/link.vars.s
@@ -252,6 +252,9 @@ linksymnum        ds    2
 linknextlbl       ds    4
 
 
+linkpos           ds    4                     ; pos / len
+linklen           ds    2
+
 opmask            ds    2                     ;EVAL variables
 number            ds    2
 bracevalid        ds    2

--- a/testdata/3013-len-pos-1.S
+++ b/testdata/3013-len-pos-1.S
@@ -1,0 +1,15 @@
+
+	rel
+
+	ext my_pos_0
+	ext my_len_1,my_pos_1
+	ext my_len_2,my_pos_2
+
+	lda #my_len_1
+	lda #my_len_2
+	ldx #my_pos_1
+	ldx #my_pos_2
+	ldy #my_pos_0
+	rtl
+
+	sav 3013-len-pos-1.L

--- a/testdata/3013-len-pos-2.S
+++ b/testdata/3013-len-pos-2.S
@@ -1,0 +1,5 @@
+	rel
+
+* make sure ds adjusts len/pos appropriately.
+	ds \
+	sav 3013-len-pos-2.L

--- a/testdata/3013-len-pos-link.S
+++ b/testdata/3013-len-pos-link.S
@@ -1,0 +1,24 @@
+
+	ovr all
+
+	asm 3013-len-pos-1.S
+	asm 3013-len-pos-2.S
+
+	lnk 3013-len-pos-1.L
+
+	len my_len_1
+	pos my_pos_1
+
+	lnk 3013-len-pos-2.L
+
+	len my_len_2
+	pos my_pos_2
+
+	pos
+	pos my_pos_0
+
+
+
+	sav 3013-len-pos
+
+	ent


### PR DESCRIPTION
From the [Merlin 8/16 supplement](https://archive.org/details/Merlin_816_Supplement/page/n1/mode/2up):

LEN LABEL: puts "LABEL" in symbol dictionary as an ENTry whose value is equal to the number of bytes of the *last* linked file.

POS LABEL: Similar to LEN, but sets LABEL equal to the number of bytes in the linked from from the start (or from the lat zero-point; see below).

POS: When used by itself with no label, POS rests the byte counter to zero for the next POS LABEL command.

The upshot of these last three commands is that the Linker can communicate the length of various linked files with later modules in the link process. This would be useful, for example, if the size of one module in a program had to be used by a later module.

---

Testing in merlin 16+, these are absolute entry labels, not GEQu labels
Merlin does not include any DS fill in the len/pos, but that decision seems questionable. An oversight perhaps.  These do include a DS fill for both.  Both work with the qasm-specific IMPort as well.