### PR TITLE
qasm - in Merlin, 'a' as an operand is ignored.

### DIFF
--- a/src/asm/asm.1.s
+++ b/src/asm/asm.1.s
@@ -2418,7 +2418,11 @@ addmode      php
              beq   :skipq
              cmp   #$22 ; "
              beq   :skipq
+             and   #$5f
+             cmp   #'A'
+             beq   :a
              jmp   :index
+
 :force8      lda   #amforce8
              tsb   myvalue
              jmp   :index
@@ -2434,6 +2438,14 @@ addmode      php
 :square      lda   #amsquare
              tsb   myvalue
              jmp   :index
+
+*  'a' (no modifier) is ignored
+:a           iny
+             lda [lineptr],y
+             cmp #' '+1
+             jlt :zero
+             dey
+             jmp :index
 
 * skip over quoted operand component.
 :skipq       sta   :q

--- a/testdata/3015-amacc.S
+++ b/testdata/3015-amacc.S
@@ -1,0 +1,10 @@
+*
+* explicit a operand (inc a, etc) is dropped.
+*
+
+	inc a
+	dec a
+	lsr a
+	asl a
+	rol a
+	ror a


### PR DESCRIPTION
Based on testing with Merlin-16+ 4.12, this seems to apply in all cases.

`inc a` -> equivalent to `inc`
`lda a` -> equivalent to `lda` (bad address mode error)

if you do have an 'a' label, you need to specify the address mode, eg

`lda |a`, `lda >a`, `lda <a`