### PR TITLE
qasm (iigs): fix AST opcode 

### DIFF
--- a/src/asm/asm.opcodes.s
+++ b/src/asm/asm.opcodes.s
@@ -3722,14 +3722,11 @@ astop         lda       passnum
               lda       #forwardref
 :sec1         sec
               rts
-:ok           ldal      tcursx
-              and       #$ff
-              cmp       #21
-              bge       :ast
-              lda       #' '
-              jsr       drawchar
-              jmp       :ok
-:ast          lda       lvalue
+:ok           lda   tabs
+              and   #$ff
+              pha
+              _QATabToCol
+              lda       lvalue
               and       #$00FF
               tay
 :loop         lda       #'*'

--- a/src/asm/asm.vars.s
+++ b/src/asm/asm.vars.s
@@ -1,7 +1,5 @@
                 tr    on
 
-tcursx          equ   $57b
-
 true            equ   $FFFF
 false           equ   $0
 


### PR DESCRIPTION
The AST opcode was using the screen hole x position ($00057b).  Replaced it with _QATabToCol.