### PR TITLE
_QAPrintDate/_QADateTime wasn't y2k compliant.

### DIFF
--- a/src/tools/qatools.1.s
+++ b/src/tools/qatools.1.s
@@ -1607,7 +1607,7 @@ QADateTime
                 and             #%0001                      ;show time?
                 beq             :gxit
                 ~QADrawCString  #tempbuff+9                 ; yes
-:gxit           bra             :xit
+:gxit           brl             :xit
 :hex
                 ~ReadTimeHex                                ;get time in hex
                 ldx             #4
@@ -1643,7 +1643,12 @@ QADateTime
                 ldy             #2
                 lda             []date],y                   ;print year
                 xba
-                jsr             zNumDraw
+                and             #$ff
+]lup            cmp             #100
+                bcc             :y2ok
+                sbc             #100
+                bra             ]lup
+:y2ok           jsr             zNumDraw
 
                 jsl             DrawSpace
 :time


### PR DESCRIPTION
Since the year component is stored as an offset from 1900 ("current year minus 1900"), 2000-2155 overflows the 2-digit year display and renders as ##.  This truncates it back to 2 digits.